### PR TITLE
fix: the assertlocalwebrequest middleware validates ... in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -1306,6 +1306,13 @@ function assertLocalWebRequest(req, res, next) {
     res.status(403).json({ error: "拒绝跨站请求。" });
     return;
   }
+  if (!origin && !referer) {
+    const remoteAddr = req.socket.remoteAddress;
+    if (!["127.0.0.1", "::1", "::ffff:127.0.0.1"].includes(remoteAddr)) {
+      res.status(403).json({ error: "拒绝跨站请求。" });
+      return;
+    }
+  }
   next();
 }
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `server.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `server.js:1289` |
| **Assessment** | Likely exploitable |

**Description**: The assertLocalWebRequest middleware validates only Origin and Referer headers, which can be omitted by attackers. Requests without these headers bypass the local-only restriction, allowing remote access to all protected endpoints.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-003` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `server.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
