### PR TITLE
[codex] backup unmerged NCM and conversion quality work

### DIFF
--- a/ncm-format.js
+++ b/ncm-format.js
@@ -73,6 +73,12 @@ function decodeMeta(metaData) {
   }
 }
 
+function coverExtension(cover) {
+  if (cover.length >= 3 && cover[0] === 0xff && cover[1] === 0xd8 && cover[2] === 0xff) return "jpg";
+  if (cover.length >= 8 && cover.subarray(0, 8).equals(Buffer.from("89504E470D0A1A0A", "hex"))) return "png";
+  return null;
+}
+
 // Try one header layout. Returns { audioData, format, meta } or null.
 function tryDecrypt(buf, keyLenOff, keyStart) {
   const keyLen = buf.readUInt32LE(keyLenOff);
@@ -105,19 +111,22 @@ function tryDecrypt(buf, keyLenOff, keyStart) {
 
   // Skip crc(4) + unknown(5) + coverLen(4) + cover(coverLen).
   let audioOff = metaOff + 4 + metaLen + 4 + 5;
-  let coverLen = 0;
+  let cover = null;
   if (audioOff + 4 <= buf.length) {
-    coverLen = buf.readUInt32LE(audioOff);
+    const coverLen = buf.readUInt32LE(audioOff);
     audioOff += 4;
+    if (coverLen > buf.length - audioOff) return null;
+    if (coverLen > 0) {
+      cover = Buffer.from(buf.subarray(audioOff, audioOff + coverLen));
+      audioOff += coverLen;
+    }
   }
-  if (coverLen < 0 || coverLen > buf.length - audioOff) return null;
-  audioOff += coverLen;
   if (audioOff >= buf.length) return null;
 
   const audioData = ncmDecrypt(rc4key, buf.subarray(audioOff));
   const format = detectAudioFormat(audioData);
   if (format === "unknown") return null;
-  return { audioData, format, meta };
+  return { audioData, format, meta, cover };
 }
 
 async function convertNcm(inputPath) {
@@ -141,7 +150,15 @@ async function convertNcm(inputPath) {
       const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "flyingmouse-ncm-"));
       const nativePath = path.join(tempDir, `native.${result.format}`);
       await fsp.writeFile(nativePath, result.audioData);
-      return { nativePath, format: result.format, tempDir, meta: result.meta };
+      let coverPath = null;
+      if (result.cover && result.cover.length) {
+        const ext = coverExtension(result.cover);
+        if (ext) {
+          coverPath = path.join(tempDir, `cover.${ext}`);
+          await fsp.writeFile(coverPath, result.cover);
+        }
+      }
+      return { nativePath, format: result.format, tempDir, meta: result.meta, coverPath };
     }
   }
   throw new Error("NCM 解密失败：文件可能不是官方网易云客户端下载的标准 NCM。");

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "desktop": "electron .",
     "dist": "electron-builder --win nsis",
     "dist:win7": "node scripts/build-win7.js",
-    "test": "node --test tests/av3a-format.test.js tests/conversion-preferences.test.js tests/i18n.test.js tests/settings-store.test.js tests/conversion.test.js tests/electron-hardening-static.test.js tests/electron-security.test.js tests/logger.test.js tests/mouse-assets.test.js tests/ui-static.test.js tests/win7-build-profile.test.js tests/win7-build-script.test.js tests/pe-metadata.test.js",
-    "test:ci": "node --test tests/av3a-format.test.js tests/conversion-preferences.test.js tests/i18n.test.js tests/settings-store.test.js tests/electron-hardening-static.test.js tests/electron-security.test.js tests/logger.test.js tests/mouse-assets.test.js tests/ui-static.test.js tests/win7-build-profile.test.js tests/win7-build-script.test.js tests/pe-metadata.test.js"
+    "test": "node --test tests/av3a-format.test.js tests/conversion-preferences.test.js tests/i18n.test.js tests/settings-store.test.js tests/conversion.test.js tests/conversion-quality.test.js tests/electron-hardening-static.test.js tests/electron-security.test.js tests/logger.test.js tests/mouse-assets.test.js tests/ui-static.test.js tests/win7-build-profile.test.js tests/win7-build-script.test.js tests/pe-metadata.test.js",
+    "test:ci": "node --test tests/av3a-format.test.js tests/conversion-preferences.test.js tests/i18n.test.js tests/settings-store.test.js tests/conversion-quality.test.js tests/electron-hardening-static.test.js tests/electron-security.test.js tests/logger.test.js tests/mouse-assets.test.js tests/ui-static.test.js tests/win7-build-profile.test.js tests/win7-build-script.test.js tests/pe-metadata.test.js"
   },
   "dependencies": {
     "@tesseract.js-data/chi_sim": "^1.0.0",

--- a/public/app.js
+++ b/public/app.js
@@ -70,7 +70,7 @@ const messages = {
     "workflow.aria": "转换流程", "workflow.select": "选择文件", "workflow.analyze": "识别格式",
     "workflow.convert": "开始转换", "workflow.save": "保存结果", "upload.aria": "上传文件",
     "upload.title": "把文件丢给鼠鼠", "upload.hint": "图片、文档、PDF、WPS、音视频都可以试",
-    "upload.limited": "PDF 表格可以转 Excel；Office/WPS 需要内置 LibreOffice",
+    "upload.limited": "PDF → Excel（智能表格提取）：适合电子版规则表格；Office/WPS 需要内置 LibreOffice",
     "action.clear": "清空", "action.convert": "开始转换", "action.download": "下载转换后的文件",
     "action.save": "保存", "action.saveAll": "保存全部", "target.label": "目标格式",
     "target.placeholder": "先选择文件", "target.analyzing": "正在识别", "target.none": "无共同目标格式",
@@ -89,7 +89,7 @@ const messages = {
     "workflow.aria": "Conversion workflow", "workflow.select": "Select files", "workflow.analyze": "Detect format",
     "workflow.convert": "Convert", "workflow.save": "Save results", "upload.aria": "Upload files",
     "upload.title": "Drop files to Mouse", "upload.hint": "Try images, documents, PDF, WPS, audio, or video",
-    "upload.limited": "PDF tables can be converted to Excel; Office/WPS needs bundled LibreOffice",
+    "upload.limited": "PDF → Excel (smart table extraction) works best on digital, regular tables; Office/WPS needs bundled LibreOffice",
     "action.clear": "Clear", "action.convert": "Convert", "action.download": "Download converted file",
     "action.save": "Save", "action.saveAll": "Save all", "target.label": "Target format",
     "target.placeholder": "Select files first", "target.analyzing": "Detecting", "target.none": "No common target format",
@@ -288,7 +288,7 @@ async function fetchCapabilities() {
   toolHealth.classList.add("ok");
 
   if (!state.capabilities.tools.libreoffice) {
-    dropHint.textContent = "PDF 表格可以转 Excel；Office/WPS 需要内置 LibreOffice";
+    dropHint.textContent = t("upload.limited");
   }
 
   renderFormatTable();

--- a/server.js
+++ b/server.js
@@ -33,6 +33,13 @@ const RUNTIME_DIR = process.env.FLYINGMOUSE_RUNTIME_DIR || path.join(os.tmpdir()
 const UPLOAD_DIR = path.join(RUNTIME_DIR, "uploads");
 const OUTPUT_DIR = path.join(RUNTIME_DIR, "converted");
 const MAX_UPLOAD_BYTES = 1024 * 1024 * 1024;
+// Safety caps: keep decode/encode memory bounded even for hostile or corrupt
+// inputs, instead of disabling Sharp's built-in pixel guard.
+const MAX_BATCH_TOTAL_BYTES = 2 * 1024 * 1024 * 1024;
+const MAX_IMAGE_PIXELS = 100 * 1000 * 1000;
+const MAX_IMAGE_DIMENSION = 30_000;
+const MAX_PDF_PAGES = 1_000;
+const MAX_OCR_PDF_PAGES = 200;
 const app = express();
 const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
@@ -181,6 +188,54 @@ async function commandExists(command, versionArgs = ["-version"]) {
   }
 }
 
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = "KB";
+  for (const next of units) {
+    if (value < 1024) break;
+    value /= 1024;
+    unit = next;
+  }
+  return `${value.toFixed(1)} ${unit}`;
+}
+
+async function assertImageWithinLimits(inputPath) {
+  const metadata = await sharp(inputPath).metadata();
+  const width = metadata.width || 0;
+  const height = metadata.height || 0;
+  const pixels = width * height;
+  if (pixels > MAX_IMAGE_PIXELS || width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
+    throw new Error(
+      `图片超出安全限制（当前 ${width}×${height}，上限：单边 ${MAX_IMAGE_DIMENSION}px / ${MAX_IMAGE_PIXELS / 1000000}MP）。`
+    );
+  }
+  return metadata;
+}
+
+async function getPdfPageCount(inputPath) {
+  const src = await PDFDocument.load(await fsp.readFile(inputPath), { ignoreEncryption: true });
+  return src.getPageCount();
+}
+
+async function assertPdfPageCountWithinLimits(inputPath, maxPages = MAX_PDF_PAGES) {
+  const count = await getPdfPageCount(inputPath);
+  if (count > maxPages) {
+    throw new Error(`PDF 页数超过限制（${count} 页，上限 ${maxPages} 页）。`);
+  }
+  return count;
+}
+
+function assertBatchSizeWithinLimits(files, maxBytes = MAX_BATCH_TOTAL_BYTES) {
+  const totalBytes = files.reduce((sum, file) => sum + (Number(file.size) || 0), 0);
+  if (totalBytes > maxBytes) {
+    throw new Error(`批量文件总大小超过限制（最多 ${formatBytes(maxBytes)}，当前 ${formatBytes(totalBytes)}）。`);
+  }
+  return totalBytes;
+}
+
 function extFromName(name = "") {
   return path.extname(name).replace(".", "").toLowerCase();
 }
@@ -244,18 +299,34 @@ function targetsForExt(rawExt, tools) {
 
   if (category === "pdf") {
     pdfTextTargets.forEach((target) => targets.add(target));
+    // PDF -> PDF (split into single-page files) uses pdf-lib only; do not
+    // gate it behind the Poppler renderer.
+    targets.add("pdf");
     if (tools.poppler) {
       pdfImageTargets.forEach((target) => targets.add(target));
-      targets.add("pdf");
     }
   }
 
-  if (category === "document" && tools.libreoffice) {
-    documentTargets.forEach((target) => targets.add(target));
+  if (category === "document") {
+    const normalizedInput = normalizeExt(rawExt);
+    if (normalizedInput === "docx") {
+      // DOCX -> Markdown/TXT use mammoth and need no LibreOffice.
+      targets.add("md");
+      targets.add("txt");
+    }
+    if (tools.libreoffice) {
+      documentTargets.forEach((target) => targets.add(target));
+    }
   }
 
-  if (category === "spreadsheet" && tools.libreoffice) {
-    spreadsheetTargets.forEach((target) => targets.add(target));
+  if (category === "spreadsheet") {
+    if (normalizeExt(rawExt) === "csv") {
+      // CSV -> JSON is engine-free and uses the RFC 4180 parser.
+      targets.add("json");
+    }
+    if (tools.libreoffice) {
+      spreadsheetTargets.forEach((target) => targets.add(target));
+    }
   }
 
   if (category === "presentation" && tools.libreoffice) {
@@ -515,28 +586,67 @@ function htmlToText(html) {
     .trim();
 }
 
-function csvToJson(csv) {
-  const rows = csv.replace(/\r\n/g, "\n").split("\n").filter(Boolean).map((line) => {
-    const cells = [];
-    let current = "";
-    let quoted = false;
-    for (let i = 0; i < line.length; i += 1) {
-      const char = line[i];
-      if (char === '"' && line[i + 1] === '"') {
-        current += '"';
-        i += 1;
-      } else if (char === '"') {
-        quoted = !quoted;
-      } else if (char === "," && !quoted) {
-        cells.push(current);
-        current = "";
+function htmlToMarkdown(html) {
+  const turndown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced", bulletListMarker: "-" });
+  return turndown.turndown(html).trim();
+}
+
+// RFC 4180 state-machine parser: handles quoted fields, escaped quotes
+// (""), embedded CR/LF inside quoted fields, mixed EOL styles and a UTF-8 BOM.
+function parseCsv(csv) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let inQuotes = false;
+  let atFieldStart = true;
+  const input = String(csv || "").replace(/^\uFEFF/, "");
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+    if (inQuotes) {
+      if (char === '"') {
+        if (input[index + 1] === '"') {
+          field += '"';
+          index += 1;
+        } else {
+          inQuotes = false;
+        }
       } else {
-        current += char;
+        field += char;
       }
+      continue;
     }
-    cells.push(current);
-    return cells;
-  });
+    if (char === '"' && atFieldStart) {
+      inQuotes = true;
+      atFieldStart = false;
+      continue;
+    }
+    if (char === ",") {
+      row.push(field);
+      field = "";
+      atFieldStart = true;
+      continue;
+    }
+    if (char === "\n" || char === "\r") {
+      if (char === "\r" && input[index + 1] === "\n") index += 1;
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+      atFieldStart = true;
+      continue;
+    }
+    field += char;
+    atFieldStart = false;
+  }
+
+  row.push(field);
+  if (row.length > 1 || field !== "" || rows.length === 0) rows.push(row);
+  return rows.filter((entry) => entry.some((cell) => cell !== ""));
+}
+
+function csvToJson(csv) {
+  const rows = parseCsv(csv);
 
   const headers = rows.shift() || [];
   return rows.map((row) => Object.fromEntries(headers.map((header, index) => [header || `column_${index + 1}`, row[index] || ""])));
@@ -551,6 +661,8 @@ function jsonToCsv(jsonText) {
 }
 
 async function convertImage(inputPath, outputPath, target) {
+  await assertImageWithinLimits(inputPath);
+
   if (target === "pdf") {
     await convertImagesToPdf([{ inputPath, originalName: path.basename(inputPath) }], outputPath);
     return;
@@ -566,7 +678,7 @@ async function convertImage(inputPath, outputPath, target) {
     return;
   }
 
-  const image = sharp(inputPath, { animated: true, limitInputPixels: false }).rotate();
+  const image = sharp(inputPath, { animated: true, limitInputPixels: MAX_IMAGE_PIXELS }).rotate();
   const normalized = target === "jpg" ? "jpeg" : target;
   await image.toFormat(normalized, target === "jpg" ? { quality: 90 } : undefined).toFile(outputPath);
 }
@@ -599,10 +711,11 @@ async function convertImageToVideo(inputPath, outputPath, target) {
 }
 
 async function prepareImageForOcr(inputPath) {
+  await assertImageWithinLimits(inputPath);
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "flyingmouse-ocr-image-"));
   const outputPath = path.join(tempDir, "ocr-input.png");
-  const metadata = await sharp(inputPath, { limitInputPixels: false }).metadata();
-  const pipeline = sharp(inputPath, { limitInputPixels: false })
+  const metadata = await sharp(inputPath).metadata();
+  const pipeline = sharp(inputPath, { limitInputPixels: MAX_IMAGE_PIXELS })
     .rotate()
     .flatten({ background: "#ffffff" })
     .grayscale()
@@ -673,7 +786,8 @@ function pdfNumber(value) {
 }
 
 async function readImageForPdf(inputPath) {
-  const { data, info } = await sharp(inputPath, { limitInputPixels: false })
+  await assertImageWithinLimits(inputPath);
+  const { data, info } = await sharp(inputPath, { limitInputPixels: MAX_IMAGE_PIXELS })
     .rotate()
     .flatten({ background: "#ffffff" })
     .toColorspace("srgb")
@@ -909,7 +1023,7 @@ async function convertText(inputPath, outputPath, inputExt, target, originalName
 <body><pre>${escapeHtml(raw)}</pre></body>
 </html>`;
   } else if (target === "md") {
-    if (source === "html") converted = htmlToText(raw);
+    if (source === "html") converted = htmlToMarkdown(raw);
     else if (source === "json") converted = `\`\`\`json\n${JSON.stringify(parseJsonText(raw), null, 2)}\n\`\`\`\n`;
   } else if (target === "json") {
     if (source === "json") converted = JSON.stringify(parseJsonText(raw), null, 2);
@@ -1006,7 +1120,7 @@ async function convertDocumentToMarkdown(inputPath, outputPath, inputExt, origin
       await fsp.rm(tempDir, { recursive: true, force: true }).catch(() => {});
     }
   }
-  const turndown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+  const turndown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced", bulletListMarker: "-" });
   const markdown = turndown.turndown(html).trim();
   if (!markdown) {
     throw new Error("文档转 Markdown 失败，未提取到任何内容。");
@@ -1202,6 +1316,9 @@ td{border:1px solid #999;padding:4px 8px;vertical-align:top}
 
 async function splitPdfToZip(inputPath, outputPath) {
   const src = await PDFDocument.load(await fsp.readFile(inputPath), { ignoreEncryption: true });
+  if (src.getPageCount() > MAX_PDF_PAGES) {
+    throw new Error(`PDF 页数超过限制（${src.getPageCount()} 页，上限 ${MAX_PDF_PAGES} 页）。`);
+  }
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "flyingmouse-pdf-split-"));
   try {
     const entries = [];
@@ -1223,6 +1340,13 @@ async function splitPdfToZip(inputPath, outputPath) {
 }
 
 async function mergePdfFiles(pdfFiles, outputPath) {
+  let totalPages = 0;
+  for (const file of pdfFiles) {
+    totalPages += await assertPdfPageCountWithinLimits(file.inputPath);
+  }
+  if (totalPages > MAX_PDF_PAGES) {
+    throw new Error(`合并后 PDF 总页数超过限制（${totalPages} 页，上限 ${MAX_PDF_PAGES} 页）。`);
+  }
   const merged = await PDFDocument.create();
   for (const file of pdfFiles) {
     const src = await PDFDocument.load(await fsp.readFile(file.inputPath), { ignoreEncryption: true });
@@ -1241,6 +1365,7 @@ async function renderPdfPages(inputPath, target = "png", dpi = 150) {
     throw new Error("PDF 转图片引擎未启用。请确认安装包内置的 Poppler 文件完整。");
   }
 
+  await assertPdfPageCountWithinLimits(inputPath);
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "flyingmouse-pdf-pages-"));
   const prefix = path.join(tempDir, "page");
   const formatArg = target === "jpg" ? "-jpeg" : "-png";
@@ -1279,6 +1404,7 @@ async function convertScannedPdfToOcrText(inputPath, outputPath) {
     throw new Error("OCR 引擎未启用。请确认安装包内置的 Tesseract 语言文件完整。");
   }
 
+  await assertPdfPageCountWithinLimits(inputPath, MAX_OCR_PDF_PAGES);
   const rendered = await renderPdfPages(inputPath, "png", 300);
   let worker = null;
   try {
@@ -1299,11 +1425,38 @@ async function convertScannedPdfToOcrText(inputPath, outputPath) {
   }
 }
 
-async function convertMedia(inputPath, outputPath, target, category) {
+function ncmMetaTags(meta) {
+  const tags = {};
+  if (!meta || typeof meta !== "object") return tags;
+  const title = meta.musicName || meta.name || meta.title;
+  if (title) tags.title = String(title).trim();
+  const artistValue = meta.artist;
+  if (Array.isArray(artistValue) && artistValue.length) {
+    const first = artistValue[0];
+    const artist = Array.isArray(first) ? String(first[0] || "") : String(first || "");
+    if (artist.trim()) tags.artist = artist.trim();
+  } else if (typeof artistValue === "string" && artistValue) {
+    if (artistValue.trim()) tags.artist = artistValue.trim();
+  }
+  if (meta.album) {
+    const album = String(meta.album).trim();
+    if (album) tags.album = album;
+  }
+  return Object.fromEntries(Object.entries(tags).filter(([, value]) => value));
+}
+
+async function convertMedia(inputPath, outputPath, target, category, options = {}) {
+  const metadata = options.metadata || null;
+  const coverPath = options.coverPath || null;
+  const embedCover = coverPath && ["mp3", "m4a"].includes(target);
   const args = ["-hide_banner", "-y", "-i", inputPath];
 
+  if (embedCover) {
+    args.push("-i", coverPath);
+  }
+
   if (["mp3", "wav", "flac", "m4a", "ogg", "aac", "opus", "wma"].includes(target)) {
-    args.push("-vn");
+    if (!embedCover) args.push("-vn");
     if (target === "mp3") args.push("-codec:a", "libmp3lame", "-q:a", "2");
     if (target === "m4a") args.push("-codec:a", "aac", "-b:a", "192k");
     if (target === "ogg") args.push("-codec:a", "libopus", "-b:a", "160k");
@@ -1318,6 +1471,22 @@ async function convertMedia(inputPath, outputPath, target, category) {
     args.push("-codec:v", "libvpx-vp9", "-crf", "32", "-b:v", "0", "-codec:a", "libopus");
   } else if (target === "mkv") {
     args.push("-codec:v", "libx264", "-preset", "medium", "-crf", "23", "-codec:a", "aac");
+  }
+
+  if (metadata && Object.keys(metadata).length) {
+    for (const [key, value] of Object.entries(metadata)) {
+      args.push("-metadata", `${key}=${value}`);
+    }
+  }
+  if (embedCover) {
+    args.push("-map", "0:a", "-map", "1:v");
+    if (target === "mp3") {
+      args.push("-id3v2_version", "3", "-c:v", "mjpeg");
+      args.push("-metadata:s:v", "title=Album cover");
+      args.push("-metadata:s:v", "comment=Cover (front)");
+    } else {
+      args.push("-c:v", "mjpeg", "-disposition:v", "attached_pic");
+    }
   }
 
   args.push(outputPath);
@@ -1424,6 +1593,14 @@ app.get("/api/capabilities", async (_req, res) => {
   res.json({
     tools,
     maxUploadBytes: MAX_UPLOAD_BYTES,
+    limits: {
+      maxUploadBytes: MAX_UPLOAD_BYTES,
+      maxBatchTotalBytes: MAX_BATCH_TOTAL_BYTES,
+      maxImagePixels: MAX_IMAGE_PIXELS,
+      maxImageDimension: MAX_IMAGE_DIMENSION,
+      maxPdfPages: MAX_PDF_PAGES,
+      maxOcrPdfPages: MAX_OCR_PDF_PAGES
+    },
     groups: {
       image: { inputs: [...imageInput].sort(), targets: [...imageFormatTargets, ...(tools.ffmpeg ? imageVideoTargets : []), ...(tools.ocr ? imageOcrTargets : [])] },
       text: { inputs: [...textInput].sort(), targets: [...textTargets, ...(tools.libreoffice ? ["pdf"] : []), "docx"] },
@@ -1437,7 +1614,7 @@ app.get("/api/capabilities", async (_req, res) => {
     },
     optional: [
       { name: "LibreOffice", enabled: tools.libreoffice, formats: ["doc", "docx", "xls", "xlsx", "ppt", "pptx", "wps", "pdf"] },
-      { name: "PDF table extractor", enabled: tools.pdf, formats: ["pdf", "xlsx", "txt", "html"] },
+      { name: "PDF → Excel（智能表格提取）", enabled: tools.pdf, formats: ["pdf", "xlsx", "txt", "html"] },
       { name: "Poppler PDF renderer", enabled: tools.poppler, formats: ["pdf", "png", "jpg"] },
       { name: "Tesseract OCR", enabled: tools.ocr, formats: ["image", "pdf", "txt"] }
     ]
@@ -1471,6 +1648,15 @@ app.post("/api/convert-images-to-pdf", assertLocalWebRequest, upload.array("file
     logger.warn(`Rejected images-to-pdf: non-image file included (${imageFiles.map((f) => f.originalName).join(", ")})`);
     await Promise.all(files.map((file) => fsp.rm(file.path, { force: true }).catch(() => {})));
     res.status(400).json({ error: "批量合并 PDF 只支持图片文件。请先移除非图片文件。" });
+    return;
+  }
+
+  try {
+    assertBatchSizeWithinLimits(files);
+  } catch (error) {
+    logger.warn(`Rejected images-to-pdf: batch too large (${files.reduce((sum, f) => sum + (f.size || 0), 0)} bytes)`);
+    await Promise.all(files.map((file) => fsp.rm(file.path, { force: true }).catch(() => {})));
+    res.status(400).json({ error: error.message });
     return;
   }
 
@@ -1516,6 +1702,15 @@ app.post("/api/merge-pdfs", assertLocalWebRequest, upload.array("files", 100), a
   if (pdfFiles.some((file) => normalizeExt(extFromName(file.originalName)) !== "pdf")) {
     await Promise.all(files.map((file) => fsp.rm(file.path, { force: true }).catch(() => {})));
     res.status(400).json({ error: "批量合并 PDF 只支持 PDF 文件。请先移除非 PDF 文件。" });
+    return;
+  }
+
+  try {
+    assertBatchSizeWithinLimits(files);
+  } catch (error) {
+    logger.warn(`Rejected merge-pdfs: batch too large (${files.reduce((sum, f) => sum + (f.size || 0), 0)} bytes)`);
+    await Promise.all(files.map((file) => fsp.rm(file.path, { force: true }).catch(() => {})));
+    res.status(400).json({ error: error.message });
     return;
   }
 
@@ -1594,6 +1789,8 @@ app.post("/api/convert", assertLocalWebRequest, upload.single("file"), async (re
         await convertDocumentToMarkdown(file.path, outputPath, inputExt, originalName);
       } else if (category === "document" && requestedTarget === "txt") {
         await convertDocumentToText(file.path, outputPath, inputExt, originalName);
+      } else if (category === "spreadsheet" && inputExt === "csv" && requestedTarget === "json") {
+        await convertText(file.path, outputPath, inputExt, requestedTarget, originalName);
       } else {
         await convertWithLibreOffice(file.path, outputPath, originalName, requestedTarget);
       }
@@ -1606,7 +1803,10 @@ app.post("/api/convert", assertLocalWebRequest, upload.single("file"), async (re
           const conversionInput = inputExt === "ncm"
             ? await prepareDecryptedAudio(decrypted)
             : decrypted.nativePath;
-          await convertMedia(conversionInput, outputPath, requestedTarget, "audio");
+          await convertMedia(conversionInput, outputPath, requestedTarget, "audio", {
+            metadata: inputExt === "ncm" ? ncmMetaTags(decrypted.meta) : {},
+            coverPath: inputExt === "ncm" ? decrypted.coverPath || null : null
+          });
         } finally {
           await fsp.rm(decrypted.tempDir, { recursive: true, force: true }).catch(() => {});
         }
@@ -1705,4 +1905,17 @@ if (require.main === module) {
   });
 }
 
-module.exports = { app, startServer, createPdfjsLoader, isMissingPdfjsEntry, loadPdfjsModule };
+module.exports = {
+  app,
+  startServer,
+  createPdfjsLoader,
+  isMissingPdfjsEntry,
+  loadPdfjsModule,
+  parseCsv,
+  csvToJson,
+  htmlToMarkdown,
+  ncmMetaTags,
+  assertImageWithinLimits,
+  assertPdfPageCountWithinLimits,
+  assertBatchSizeWithinLimits
+};

--- a/tests/conversion-quality.test.js
+++ b/tests/conversion-quality.test.js
@@ -1,0 +1,160 @@
+const assert = require("assert");
+const fs = require("fs");
+const fsp = require("fs/promises");
+const os = require("os");
+const path = require("path");
+const { after, before, test } = require("node:test");
+const sharp = require("sharp");
+const serverModule = require("../server");
+const { convertNcm } = require("../ncm-format");
+
+const scratchRoot = path.join(os.tmpdir(), `flyingmouse-quality-tests-${process.pid}`);
+let server;
+let baseUrl;
+
+async function parseBody(response) {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+}
+
+async function uploadConvert(filePath, fileName, targetFormat, mimeType = "application/octet-stream") {
+  const form = new FormData();
+  form.append("file", new Blob([await fsp.readFile(filePath)], { type: mimeType }), fileName);
+  form.append("targetFormat", targetFormat);
+  const response = await fetch(`${baseUrl}/api/convert`, { method: "POST", body: form });
+  const body = await parseBody(response);
+  return { response, body };
+}
+
+async function downloadResult(result, outputName) {
+  const response = await fetch(`${baseUrl}${result.downloadUrl}`);
+  assert.strictEqual(response.status, 200, `download failed for ${result.downloadUrl}`);
+  const outputPath = path.join(scratchRoot, outputName);
+  await fsp.writeFile(outputPath, Buffer.from(await response.arrayBuffer()));
+  return outputPath;
+}
+
+before(async () => {
+  await fsp.rm(scratchRoot, { recursive: true, force: true });
+  await fsp.mkdir(scratchRoot, { recursive: true });
+  const started = await serverModule.startServer(0);
+  server = started.server;
+  baseUrl = started.url;
+});
+
+after(async () => {
+  if (server) await new Promise((resolve) => server.close(resolve));
+  await fsp.rm(scratchRoot, { recursive: true, force: true }).catch(() => {});
+});
+
+test("capabilities advertise resource limits and the smart PDF → Excel label", async () => {
+  const response = await fetch(`${baseUrl}/api/capabilities`);
+  const body = await response.json();
+  assert.strictEqual(response.status, 200);
+  assert.ok(body.limits, "capabilities must expose limits");
+  assert.strictEqual(body.limits.maxImagePixels, 100 * 1000 * 1000);
+  assert.strictEqual(body.limits.maxImageDimension, 30_000);
+  assert.strictEqual(body.limits.maxPdfPages, 1_000);
+  assert.strictEqual(body.limits.maxOcrPdfPages, 200);
+  assert.ok(body.limits.maxBatchTotalBytes >= 2 * 1024 * 1024 * 1024);
+  assert.ok(
+    body.optional.some((item) => /智能表格提取|smart table/i.test(item.name)),
+    "PDF table extractor label must mention smart extraction"
+  );
+});
+
+test("HTML → Markdown keeps headings and lists via Turndown", async () => {
+  const sourcePath = path.join(scratchRoot, "article.html");
+  await fsp.writeFile(
+    sourcePath,
+    "<h1>Hello</h1>\n<ul>\n<li>A</li>\n<li>B</li>\n</ul>\n<p>Body <strong>bold</strong> text.</p>",
+    "utf8"
+  );
+  const { response, body } = await uploadConvert(sourcePath, "article.html", "md", "text/html");
+  assert.strictEqual(response.status, 200, body.error);
+  const outputPath = await downloadResult(body, "article.md");
+  const markdown = await fsp.readFile(outputPath, "utf8");
+  assert.match(markdown, /^# Hello\s*$/m);
+  assert.match(markdown, /^-\s+A\s*$/m);
+  assert.match(markdown, /^-\s+B\s*$/m);
+  assert.match(markdown, /\*\*bold\*\*/);
+});
+
+test("CSV → JSON handles quoted fields with embedded newlines", async () => {
+  const csv = '"name","description"\n"鼠鼠","第一行\n第二行"\n"cat","say ""hi"""\n';
+  const sourcePath = path.join(scratchRoot, "multiline.csv");
+  await fsp.writeFile(sourcePath, csv, "utf8");
+
+  const { response, body } = await uploadConvert(sourcePath, "multiline.csv", "json", "text/csv");
+  assert.strictEqual(response.status, 200, body.error);
+  const outputPath = await downloadResult(body, "multiline.json");
+  const parsed = JSON.parse(await fsp.readFile(outputPath, "utf8"));
+  assert.deepStrictEqual(parsed, [
+    { name: "鼠鼠", description: "第一行\n第二行" },
+    { name: "cat", description: 'say "hi"' }
+  ]);
+});
+
+test("CSV parser handles CRLF, escaped quotes and trailing newlines", () => {
+  const rows = serverModule.parseCsv('a,b\r\n"x","1,2"\r\n"q""q",z\r\n');
+  assert.deepStrictEqual(rows, [
+    ["a", "b"],
+    ["x", "1,2"],
+    ['q"q', "z"]
+  ]);
+});
+
+test("oversized image dimensions are rejected with a clear safety error", async () => {
+  const sourcePath = path.join(scratchRoot, "oversized.png");
+  await sharp({
+    create: { width: 30_001, height: 1, channels: 3, background: { r: 1, g: 2, b: 3 } }
+  })
+    .png()
+    .toFile(sourcePath);
+
+  const { response, body } = await uploadConvert(sourcePath, "oversized.png", "jpg", "image/png");
+  assert.strictEqual(response.status, 500, "oversized image must be rejected");
+  assert.match(body.error, /安全限制|limit/i);
+});
+
+test("NCM decryption exposes cover art and song metadata (engine-free)", async (t) => {
+  const fixture = path.join(__dirname, "fixtures", "sample.ncm");
+  if (!fs.existsSync(fixture)) {
+    t.skip("缺少真实 NCM fixture（官方网易云客户端下载，放入 tests/fixtures/sample.ncm）");
+    return;
+  }
+  const result = await convertNcm(fixture);
+  try {
+    assert.ok(result.nativePath, "native audio must be written");
+    assert.ok(result.coverPath, "cover art must be extracted");
+    const cover = await fsp.readFile(result.coverPath);
+    const isJpeg = cover.length >= 3 && cover[0] === 0xff && cover[1] === 0xd8 && cover[2] === 0xff;
+    const isPng = cover.length >= 8 && cover.subarray(0, 8).equals(Buffer.from("89504E470D0A1A0A", "hex"));
+    assert.ok(isJpeg || isPng, "cover must be a valid JPEG or PNG image");
+    assert.ok(result.meta, "meta must be decoded");
+    const title = result.meta.musicName || result.meta.name || result.meta.title;
+    assert.ok(title, "meta must include a song title");
+  } finally {
+    await fsp.rm(result.tempDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("NCM metadata mapping fills title, artist and album", () => {
+  const tags = serverModule.ncmMetaTags({
+    musicName: "Happy Song",
+    artist: [["Mouse Singer"]],
+    album: "Tiny Fish"
+  });
+  assert.deepStrictEqual(tags, {
+    title: "Happy Song",
+    artist: "Mouse Singer",
+    album: "Tiny Fish"
+  });
+  assert.deepStrictEqual(serverModule.ncmMetaTags(null), {});
+  assert.deepStrictEqual(serverModule.ncmMetaTags({ musicName: "  " }), {});
+});

--- a/tests/conversion.test.js
+++ b/tests/conversion.test.js
@@ -10,9 +10,12 @@ const sharp = require("sharp");
 const serverModule = process.env.FLYINGMOUSE_FORMAT_BASE_URL ? null : require("../server");
 
 const scratchRoot = path.join(os.tmpdir(), `flyingmouse-format-tests-${process.pid}`);
-const FFMPEG_BIN = path.join(__dirname, "..", "bin", "ffmpeg", "ffmpeg.exe");
+const FFMPEG_BIN = fs.existsSync(path.join(__dirname, "..", "bin", "ffmpeg", "ffmpeg.exe"))
+  ? path.join(__dirname, "..", "bin", "ffmpeg", "ffmpeg.exe")
+  : (process.env.FLYINGMOUSE_FFMPEG_PATH || "");
 let server;
 let baseUrl;
+let tools = null;
 
 function hashFile(filePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
@@ -125,16 +128,71 @@ function assertPdf(filePath) {
 }
 
 function assertZipWithEntry(filePath, expectedFragment) {
-  const fd = fs.openSync(filePath, "r");
-  try {
-    const header = Buffer.alloc(4);
-    fs.readSync(fd, header, 0, 4, 0);
-    assert.strictEqual(header.toString("latin1"), "PK\u0003\u0004");
-  } finally {
-    fs.closeSync(fd);
+  const buf = fs.readFileSync(filePath);
+  assert.strictEqual(buf.subarray(0, 4).toString("latin1"), "PK\u0003\u0004", "zip local header missing");
+  // Walk the central directory (engine-free) to collect entry names.
+  let eocd = -1;
+  for (let index = buf.length - 22; index >= 0; index -= 1) {
+    if (buf.readUInt32LE(index) === 0x06054b50) {
+      eocd = index;
+      break;
+    }
   }
-  const listing = execFileSync("tar", ["-tf", filePath], { encoding: "utf8" });
-  assert.match(listing, expectedFragment);
+  assert.ok(eocd >= 0, "zip EOCD record missing");
+  const entryCount = buf.readUInt16LE(eocd + 10);
+  const cdOffset = buf.readUInt32LE(eocd + 16);
+  let offset = cdOffset;
+  const names = [];
+  for (let index = 0; index < entryCount; index += 1) {
+    assert.strictEqual(buf.readUInt32LE(offset), 0x02014b50, "zip central directory signature missing");
+    const nameLength = buf.readUInt16LE(offset + 28);
+    const extraLength = buf.readUInt16LE(offset + 30);
+    const commentLength = buf.readUInt16LE(offset + 32);
+    names.push(buf.subarray(offset + 46, offset + 46 + nameLength).toString("utf8"));
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+  assert.ok(
+    names.some((name) => expectedFragment.test(name)),
+    `zip must contain an entry matching ${expectedFragment}, got: ${names.join(", ")}`
+  );
+}
+
+function extractZip(filePath, outDir) {
+  const zlib = require("zlib");
+  const buf = fs.readFileSync(filePath);
+  let eocd = -1;
+  for (let index = buf.length - 22; index >= 0; index -= 1) {
+    if (buf.readUInt32LE(index) === 0x06054b50) {
+      eocd = index;
+      break;
+    }
+  }
+  assert.ok(eocd >= 0, "zip EOCD record missing");
+  const entryCount = buf.readUInt16LE(eocd + 10);
+  const cdOffset = buf.readUInt32LE(eocd + 16);
+  let offset = cdOffset;
+  for (let index = 0; index < entryCount; index += 1) {
+    assert.strictEqual(buf.readUInt32LE(offset), 0x02014b50, "zip central directory signature missing");
+    const method = buf.readUInt16LE(offset + 10);
+    const compressedSize = buf.readUInt32LE(offset + 20);
+    const uncompressedSize = buf.readUInt32LE(offset + 24);
+    const nameLength = buf.readUInt16LE(offset + 28);
+    const extraLength = buf.readUInt16LE(offset + 30);
+    const commentLength = buf.readUInt16LE(offset + 32);
+    const localOffset = buf.readUInt32LE(offset + 42);
+    const name = buf.subarray(offset + 46, offset + 46 + nameLength).toString("utf8");
+    offset += 46 + nameLength + extraLength + commentLength;
+
+    const localNameLength = buf.readUInt16LE(localOffset + 26);
+    const localExtraLength = buf.readUInt16LE(localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLength + localExtraLength;
+    const data = buf.subarray(dataStart, dataStart + compressedSize);
+    const raw = method === 0 ? data : method === 8 ? zlib.inflateRawSync(data) : null;
+    assert.ok(raw !== null && raw.length === uncompressedSize, `unexpected zip entry: ${name}`);
+    const target = path.join(outDir, name);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, raw);
+  }
 }
 
 before(async () => {
@@ -147,6 +205,8 @@ before(async () => {
     server = started.server;
     baseUrl = started.url;
   }
+  const capabilitiesResponse = await fetch(`${baseUrl}/api/capabilities`);
+  tools = (await capabilitiesResponse.json()).tools;
 });
 
 after(async () => {
@@ -191,7 +251,8 @@ test("merges multiple images into one PDF without changing any source image", as
   assert.deepStrictEqual([hashFile(firstPath), hashFile(secondPath)], hashes);
 });
 
-test("renders PDF pages to a PNG zip without changing the source PDF", async () => {
+test("renders PDF pages to a PNG zip without changing the source PDF", async (t) => {
+  if (!tools?.poppler) return t.skip("Poppler 未启用，跳过 PDF 渲染测试");
   const sourcePath = path.join(scratchRoot, "报价单.pdf");
   await createTextPdf(sourcePath);
   const beforeHash = hashFile(sourcePath);
@@ -205,7 +266,8 @@ test("renders PDF pages to a PNG zip without changing the source PDF", async () 
   assert.strictEqual(hashFile(sourcePath), beforeHash);
 });
 
-test("renders PDF pages to a JPG zip without changing the source PDF", async () => {
+test("renders PDF pages to a JPG zip without changing the source PDF", async (t) => {
+  if (!tools?.poppler) return t.skip("Poppler 未启用，跳过 PDF 渲染测试");
   const sourcePath = path.join(scratchRoot, "picture-export.pdf");
   await createTextPdf(sourcePath);
   const beforeHash = hashFile(sourcePath);
@@ -234,7 +296,8 @@ test("OCR converts an image containing text to TXT without changing the source",
   assert.strictEqual(hashFile(sourcePath), beforeHash);
 });
 
-test("OCR converts an image-only PDF to TXT without changing the source PDF", async () => {
+test("OCR converts an image-only PDF to TXT without changing the source PDF", async (t) => {
+  if (!tools?.poppler) return t.skip("Poppler 未启用，跳过扫描 PDF OCR 测试");
   const imagePath = path.join(scratchRoot, "ocr-pdf-source.png");
   await createTextImage(imagePath);
   const imageToPdf = await uploadConvert(imagePath, "ocr-pdf-source.png", "pdf", "image/png");
@@ -307,7 +370,8 @@ test("PDF table extraction to XLSX keeps rows and cells", async () => {
   assert.match(joined, /Apple/);
 });
 
-test("audio files must not offer video container targets", async () => {
+test("audio files must not offer video container targets", async (t) => {
+  if (!tools?.ffmpeg) return t.skip("FFmpeg 未启用，跳过音频目标测试");
   const response = await fetch(`${baseUrl}/api/targets`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -323,7 +387,8 @@ test("audio files must not offer video container targets", async () => {
   assert.ok(body.targets.includes("zip"), "mp3 must still offer zip");
 });
 
-test("video files keep both audio and video targets", async () => {
+test("video files keep both audio and video targets", async (t) => {
+  if (!tools?.ffmpeg) return t.skip("FFmpeg 未启用，跳过视频目标测试");
   const response = await fetch(`${baseUrl}/api/targets`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -381,7 +446,8 @@ test("local-origin conversion requests are allowed", async () => {
   assert.strictEqual(hashFile(sourcePath), beforeHash);
 });
 
-test("audio files offer the new AAC/OPUS/WMA outputs", async () => {
+test("audio files offer the new AAC/OPUS/WMA outputs", async (t) => {
+  if (!tools?.ffmpeg) return t.skip("FFmpeg 未启用，跳过音频新格式测试");
   const response = await fetch(`${baseUrl}/api/targets`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -394,7 +460,8 @@ test("audio files offer the new AAC/OPUS/WMA outputs", async () => {
   assert.ok(body.targets.includes("wma"), `mp3 must offer wma, got ${body.targets.join(",")}`);
 });
 
-test("image files offer MP4/WebM video outputs when ffmpeg is available", async () => {
+test("image files offer MP4/WebM video outputs when ffmpeg is available", async (t) => {
+  if (!tools?.ffmpeg) return t.skip("FFmpeg 未启用，跳过图片转视频目标测试");
   const response = await fetch(`${baseUrl}/api/targets`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -406,7 +473,8 @@ test("image files offer MP4/WebM video outputs when ffmpeg is available", async 
   assert.ok(body.targets.includes("webm"), `gif must offer webm, got ${body.targets.join(",")}`);
 });
 
-test("text files offer PDF output when LibreOffice is available", async () => {
+test("text files offer PDF output when LibreOffice is available", async (t) => {
+  if (!tools?.libreoffice) return t.skip("LibreOffice 未启用，跳过文本转 PDF 目标测试");
   const response = await fetch(`${baseUrl}/api/targets`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -417,7 +485,8 @@ test("text files offer PDF output when LibreOffice is available", async () => {
   assert.ok(body.targets.includes("pdf"), `txt must offer pdf, got ${body.targets.join(",")}`);
 });
 
-test("converts a TXT file to PDF without changing the source", async () => {
+test("converts a TXT file to PDF without changing the source", async (t) => {
+  if (!tools?.libreoffice) return t.skip("LibreOffice 未启用，跳过 TXT 转 PDF 测试");
   const sourcePath = path.join(scratchRoot, "notes.txt");
   await fsp.writeFile(sourcePath, "line one\nline two", "utf8");
   const beforeHash = hashFile(sourcePath);
@@ -431,7 +500,8 @@ test("converts a TXT file to PDF without changing the source", async () => {
   assert.strictEqual(hashFile(sourcePath), beforeHash);
 });
 
-test("converts a Markdown file to PDF without changing the source", async () => {
+test("converts a Markdown file to PDF without changing the source", async (t) => {
+  if (!tools?.libreoffice) return t.skip("LibreOffice 未启用，跳过 Markdown 转 PDF 测试");
   const sourcePath = path.join(scratchRoot, "readme.md");
   await fsp.writeFile(sourcePath, "# Title\n\nSome **bold** text.", "utf8");
   const beforeHash = hashFile(sourcePath);
@@ -495,7 +565,7 @@ test("splits a PDF into a per-page PDF zip without changing the source", async (
   const extractDir = path.join(scratchRoot, "split-out");
   await fsp.rm(extractDir, { recursive: true, force: true });
   await fsp.mkdir(extractDir, { recursive: true });
-  execFileSync("tar", ["-xf", zipPath, "-C", extractDir]);
+  extractZip(zipPath, extractDir);
   const { PDFDocument } = require("pdf-lib");
   const page1 = await PDFDocument.load(await fsp.readFile(path.join(extractDir, "page-001.pdf")));
   const page2 = await PDFDocument.load(await fsp.readFile(path.join(extractDir, "page-002.pdf")));
@@ -504,7 +574,8 @@ test("splits a PDF into a per-page PDF zip without changing the source", async (
   assert.strictEqual(hashFile(twoPagePdf), beforeHash);
 });
 
-test("converts an animated GIF to MP4 without changing the source", async () => {
+test("converts an animated GIF to MP4 without changing the source", async (t) => {
+  if (!tools?.ffmpeg) return t.skip("FFmpeg 未启用，跳过 GIF 转 MP4 测试");
   const sourcePath = path.join(scratchRoot, "anim.gif");
   execFileSync(FFMPEG_BIN, ["-hide_banner", "-y", "-f", "lavfi", "-i", "testsrc=duration=1:size=64x64:rate=10", sourcePath]);
   const beforeHash = hashFile(sourcePath);
@@ -525,7 +596,8 @@ test("converts an animated GIF to MP4 without changing the source", async () => 
   assert.strictEqual(hashFile(sourcePath), beforeHash);
 });
 
-test("converts audio to AAC, OPUS and WMA outputs without changing the source", async () => {
+test("converts audio to AAC, OPUS and WMA outputs without changing the source", async (t) => {
+  if (!tools?.ffmpeg) return t.skip("FFmpeg 未启用，跳过音频转码测试");
   const sourcePath = path.join(scratchRoot, "tone.wav");
   execFileSync(FFMPEG_BIN, ["-hide_banner", "-y", "-f", "lavfi", "-i", "sine=frequency=440:duration=1", sourcePath]);
   const beforeHash = hashFile(sourcePath);
@@ -615,7 +687,8 @@ test("converts a DOCX to plain text without LibreOffice txt export", async () =>
   assert.strictEqual(hashFile(sourcePath), beforeHash);
 });
 
-test("converts a DOCX to PDF via LibreOffice", async () => {
+test("converts a DOCX to PDF via LibreOffice", async (t) => {
+  if (!tools?.libreoffice) return t.skip("LibreOffice 未启用，跳过 DOCX 转 PDF 测试");
   const sourcePath = path.join(scratchRoot, "文档转PDF.docx");
   await createMinimalDocx(sourcePath, "PDF content here");
   const beforeHash = hashFile(sourcePath);
@@ -630,6 +703,7 @@ test("converts a DOCX to PDF via LibreOffice", async () => {
 });
 
 test("decrypts a standard NetEase NCM file to MP3 (real fixture required)", async (t) => {
+  if (!tools?.ffmpeg) return t.skip("FFmpeg 未启用，跳过 NCM 转 MP3 测试");
   const fixture = path.join(__dirname, "fixtures", "sample.ncm");
   if (!fs.existsSync(fixture)) {
     t.skip("缺少真实 NCM fixture（官方网易云客户端下载，放入 tests/fixtures/sample.ncm）");
@@ -649,6 +723,7 @@ test("decrypts a standard NetEase NCM file to MP3 (real fixture required)", asyn
 });
 
 test("decrypts a Kugou KGG file to audio (real fixture + key db required)", async (t) => {
+  if (!tools?.ffmpeg) return t.skip("FFmpeg 未启用，跳过 KGG 转 MP3 测试");
   const fixture = path.join(__dirname, "fixtures", "sample.kgg");
   if (!fs.existsSync(fixture)) {
     t.skip("缺少真实 KGG fixture（酷狗客户端下载，放入 tests/fixtures/sample.kgg）");


### PR DESCRIPTION
## What changed

Backs up the unmerged local NCM cover/metadata work, conversion resource limits, HTML/CSV quality changes, UI copy, and associated tests before the local development trees are removed.

## Why

These changes were not present on GitHub. This draft preserves them for later comparison with the published v0.3.3 implementation; it is not intended for direct merge without reconciliation.

## Validation

- `git diff --check`
- `npm run test:ci` — 106 passed, 0 failed

## Review note

This branch started from the older v0.3.2 development baseline and overlaps current v0.3.3 code. Resolve or cherry-pick selectively; do not merge blindly.