### PR TITLE
新增转换结果预览、CLI 与 Agent 一键接入

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 - 路径记忆：记住上次保存目录，下次保存时自动从该目录开始。
 - 中文/English 界面：首次启动跟随系统语言，手动选择后会记住设置。
 - 批量转换：显示逐文件进度、结果和失败原因，并可单独保存或保存全部。
+- 结果预览：转换完成后可在侧边抽屉预览图片、PDF、文本、音频和视频；窄窗口自动切换为底部面板。
+- CLI 与 Agent 接入：命令行覆盖能力查询、目标查询、单个/批量转换、图片合并 PDF 和 PDF 合并；应用内可把配套 skill 一键接入现有 Codex、Claude 或通用 Agent 目录。
 - 转换质量：HTML / Office 转 Markdown 保留标题、列表和代码块；CSV 支持 BOM、转义引号和字段内换行。
 - PDF → Excel（智能表格提取）：支持电子文字坐标、扫描页 OCR、有框/无框表格、多表、跨页续接、合并单元格、低置信度批注与 Raw 回退。
 - PDF → Word（版式还原）：内置 pdf2docx 引擎还原段落、表格、图片、字体与布局；扫描版自动 OCR 回退。Windows 10/11 版支持版式还原，Windows 7 版回退到文字提取。
@@ -53,6 +55,19 @@
 npm install
 npm run desktop
 ```
+
+命令行示例：
+
+```powershell
+node cli.js capabilities --json
+node cli.js targets example.pdf --json
+node cli.js convert input.docx --to pdf --output output.pdf --json
+node cli.js convert a.png b.png --to webp --output-dir converted --json
+node cli.js images-to-pdf 1.jpg 2.jpg --output album.pdf --json
+node cli.js merge-pdfs a.pdf b.pdf --output merged.pdf --json
+```
+
+安装版也可直接调用应用入口：macOS 使用 `FlyingMouse Format.app/Contents/MacOS/FlyingMouse Format --cli ...`，Windows 使用 `FlyingMouse Format.exe --cli ...`。在软件顶部点击“接入 Agent”，会检索已存在的 `~/.codex/skills`、`~/.claude/skills`、`~/.agents/skills`（Windows 对应用户目录）并在确认后安装或更新 skill；不会自动创建未安装产品的目录。
 
 运行测试与打包：
 
@@ -101,6 +116,8 @@ Win7 staging 使用专用 `win7-package-lock.json` 和 `npm ci` 重建；推荐�
 - Remembers the last save directory for the next save dialog.
 - Chinese and English UI. The first launch follows the system language; a manual choice is remembered.
 - Batch conversion with per-file progress, results, error details, individual save, and Save All.
+- Result previews for images, PDFs, text, audio, and video in a responsive side drawer / bottom sheet.
+- A complete CLI plus one-click Agent skill installation for existing Codex, Claude, and generic Agent skill directories.
 - Higher-quality text conversion: structural HTML/Office Markdown plus standards-compliant quoted and multiline CSV parsing.
 - PDF → Excel smart table extraction for digital text and scanned pages, including multiple tables, continued pages, merged cells, confidence notes, and Raw fallback.
 - PDF → Word (layout-preserving): the bundled pdf2docx engine restores paragraphs, tables, images, fonts, and layout; scanned PDFs fall back to OCR. Layout restoration is available on Windows 10/11; Windows 7 falls back to text extraction.
@@ -120,6 +137,19 @@ Win7 staging 使用专用 `win7-package-lock.json` 和 `npm ci` 重建；推荐�
 4. Choose a save location. The app remembers both the target preference and save folder.
 
 > The source repository excludes the large FFmpeg, LibreOffice, Poppler, and Tesseract bundles. Regular users should install the Release build. Developers need to provide the corresponding resources under `bin/` for the complete conversion feature set.
+
+CLI examples:
+
+```powershell
+node cli.js capabilities --json
+node cli.js targets example.pdf --json
+node cli.js convert input.docx --to pdf --output output.pdf --json
+node cli.js convert a.png b.png --to webp --output-dir converted --json
+node cli.js images-to-pdf 1.jpg 2.jpg --output album.pdf --json
+node cli.js merge-pdfs a.pdf b.pdf --output merged.pdf --json
+```
+
+Packaged builds accept the same commands after `--cli`: use `FlyingMouse Format.app/Contents/MacOS/FlyingMouse Format --cli ...` on macOS or `FlyingMouse Format.exe --cli ...` on Windows. “Connect to Agent” discovers existing Codex, Claude, and generic Agent skill directories and installs the bundled lightweight wrapper after confirmation.
 
 ### Choose a Windows build
 

--- a/agent-skill-installer.js
+++ b/agent-skill-installer.js
@@ -1,0 +1,126 @@
+"use strict";
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { randomUUID } = require("node:crypto");
+
+const SKILL_NAME = "flyingmouse-format";
+
+function candidateSkillRoots({ home = os.homedir(), platform = process.platform, env = process.env } = {}) {
+  const userHome = platform === "win32" ? (env.USERPROFILE || home) : home;
+  const candidates = [];
+  const codexHome = env.CODEX_HOME ? path.resolve(env.CODEX_HOME) : path.join(userHome, ".codex");
+  candidates.push({ id: "codex", name: "Codex", path: path.join(codexHome, "skills") });
+  candidates.push({ id: "claude", name: "Claude", path: path.join(userHome, ".claude", "skills") });
+  candidates.push({ id: "agents", name: "Agents", path: path.join(userHome, ".agents", "skills") });
+  return candidates;
+}
+
+async function discoverSkillRoots(options = {}) {
+  const discovered = [];
+  const seen = new Set();
+  for (const candidate of candidateSkillRoots(options)) {
+    const resolved = path.resolve(candidate.path);
+    const key = options.platform === "win32" ? resolved.toLowerCase() : resolved;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const stat = await fsp.lstat(resolved).catch(() => null);
+    if (stat?.isDirectory() && !stat.isSymbolicLink()) discovered.push({ ...candidate, path: resolved });
+  }
+  return discovered;
+}
+
+function assertSafeSkillName(name) {
+  if (!/^[a-z0-9-]+$/.test(name)) throw new Error("Invalid skill name.");
+}
+
+async function assertRealDirectory(directory, label) {
+  const stat = await fsp.lstat(directory).catch(() => null);
+  if (stat?.isSymbolicLink()) throw new Error(`${label} must not be a symbolic link: ${directory}`);
+  if (!stat?.isDirectory()) throw new Error(`${label} is not an existing directory: ${directory}`);
+  return fsp.realpath(directory);
+}
+
+async function validateSourceTree(sourceDir) {
+  const realSource = await assertRealDirectory(sourceDir, "Skill source");
+  const required = ["SKILL.md", path.join("scripts", "flyingmouse-format.js")];
+  for (const entry of required) {
+    const stat = await fsp.stat(path.join(realSource, entry)).catch(() => null);
+    if (!stat?.isFile()) throw new Error(`Bundled skill is missing ${entry}.`);
+  }
+  return realSource;
+}
+
+async function copyDirectorySafe(source, destination) {
+  await fsp.cp(source, destination, {
+    recursive: true,
+    force: false,
+    errorOnExist: true,
+    filter(item) {
+      const stat = fs.lstatSync(item);
+      if (stat.isSymbolicLink()) throw new Error(`Skill source contains a symbolic link: ${item}`);
+      return true;
+    }
+  });
+}
+
+async function installOne({ sourceDir, root, launcher, skillName }) {
+  const realRoot = await assertRealDirectory(root.path, `${root.name} skill root`);
+  const destination = path.join(realRoot, skillName);
+  const temp = path.join(realRoot, `.${skillName}.install-${randomUUID()}`);
+  const backup = path.join(realRoot, `.${skillName}.backup-${randomUUID()}`);
+  const destinationStat = await fsp.lstat(destination).catch(() => null);
+  let backupCanBeRemoved = false;
+  if (destinationStat?.isSymbolicLink()) throw new Error(`Existing skill must not be a symbolic link: ${destination}`);
+
+  try {
+    await copyDirectorySafe(sourceDir, temp);
+    await fsp.writeFile(path.join(temp, "launcher.json"), `${JSON.stringify({
+      schemaVersion: 1,
+      executable: path.resolve(launcher.executable),
+      args: Array.isArray(launcher.args) ? launcher.args.map(String) : []
+    }, null, 2)}\n`, { encoding: "utf8", flag: "wx" });
+
+    if (destinationStat) await fsp.rename(destination, backup);
+    try {
+      await fsp.rename(temp, destination);
+    } catch (error) {
+      if (destinationStat) await fsp.rename(backup, destination).catch(() => {});
+      throw error;
+    }
+    backupCanBeRemoved = true;
+    if (destinationStat) await fsp.rm(backup, { recursive: true, force: true });
+    return { id: root.id, name: root.name, path: destination, updated: Boolean(destinationStat) };
+  } finally {
+    await fsp.rm(temp, { recursive: true, force: true }).catch(() => {});
+    if (backupCanBeRemoved) await fsp.rm(backup, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function installAgentSkill({ sourceDir, roots, launcher, skillName = SKILL_NAME }) {
+  assertSafeSkillName(skillName);
+  const source = await validateSourceTree(sourceDir);
+  if (!launcher?.executable || !path.isAbsolute(launcher.executable)) {
+    throw new Error("Agent skill launcher executable must be an absolute path.");
+  }
+  const installed = [];
+  const failed = [];
+  for (const root of roots || []) {
+    try {
+      installed.push(await installOne({ sourceDir: source, root, launcher, skillName }));
+    } catch (error) {
+      failed.push({ id: root.id, name: root.name, path: root.path, error: error.message });
+    }
+  }
+  if (!installed.length && failed.length === 1) throw new Error(failed[0].error);
+  return { installed, failed };
+}
+
+module.exports = {
+  SKILL_NAME,
+  candidateSkillRoots,
+  discoverSkillRoots,
+  installAgentSkill
+};

--- a/agent-skill/flyingmouse-format/SKILL.md
+++ b/agent-skill/flyingmouse-format/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: flyingmouse-format
+description: Use FlyingMouse Format's local offline CLI to inspect supported conversions and convert images, text, documents, spreadsheets, presentations, PDFs, archives, audio, and video. Trigger when a user asks to convert file formats, merge images into PDF, merge PDFs, inspect available target formats, or automate these operations from an agent.
+---
+
+# FlyingMouse Format
+
+Use the bundled wrapper at `scripts/flyingmouse-format.js`. It locates the FlyingMouse Format application configured by the in-app “Connect to Agent” action and invokes its CLI.
+
+## Workflow
+
+1. Check available targets before an unfamiliar conversion:
+
+   `node scripts/flyingmouse-format.js targets <file> --json`
+
+2. Convert one or more independent files:
+
+   `node scripts/flyingmouse-format.js convert <files...> --to <format> --output-dir <directory> --json`
+
+3. Merge images into one PDF:
+
+   `node scripts/flyingmouse-format.js images-to-pdf <images...> --output <result.pdf> --json`
+
+4. Merge PDFs:
+
+   `node scripts/flyingmouse-format.js merge-pdfs <pdfs...> --output <result.pdf> --json`
+
+5. Use `capabilities --json` when engine availability matters.
+
+## Options
+
+- ZIP: `--compression-level 0..9`
+- Video: `--video-codec h264|h265|av1`
+- PDF: `--pdf-action encrypt|decrypt --password <password>`
+- Prefer `--json` and read `outputs[].path` from stdout.
+- Never echo or log a PDF password.
+- Preserve the user's requested output directory and do not overwrite existing files without permission.
+
+If the wrapper reports that FlyingMouse Format is missing, ask the user to open the application and use “Connect to Agent” again.

--- a/agent-skill/flyingmouse-format/agents/openai.yaml
+++ b/agent-skill/flyingmouse-format/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "FlyingMouse Format"
+  short_description: "Convert files with FlyingMouse Format's offline CLI"
+  default_prompt: "Use $flyingmouse-format to inspect supported targets and convert the user's local files."

--- a/agent-skill/flyingmouse-format/scripts/flyingmouse-format.js
+++ b/agent-skill/flyingmouse-format/scripts/flyingmouse-format.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const skillRoot = path.join(__dirname, "..");
+const configPath = path.join(skillRoot, "launcher.json");
+
+function fail(message) {
+  process.stderr.write(`${JSON.stringify({ ok: false, error: message, errorCode: "FLYINGMOUSE_LAUNCH_FAILED" })}\n`);
+  process.exit(1);
+}
+
+let config;
+try {
+  config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+} catch {
+  fail("FlyingMouse Format is not connected. Open the app and choose Connect to Agent.");
+}
+
+if (!path.isAbsolute(config.executable) || !fs.existsSync(config.executable)) {
+  fail("The configured FlyingMouse Format executable no longer exists. Reconnect it from the app.");
+}
+
+const result = spawnSync(config.executable, [...(config.args || []), "--cli", ...process.argv.slice(2)], {
+  stdio: "inherit",
+  windowsHide: true
+});
+if (result.error) fail(result.error.message);
+process.exit(result.status == null ? 1 : result.status);

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const http = require("node:http");
+const path = require("node:path");
+const { randomUUID } = require("node:crypto");
+
+const VALUE_OPTIONS = new Map([
+  ["--to", "to"],
+  ["--output", "output"],
+  ["--output-dir", "outputDir"],
+  ["--compression-level", "compressionLevel"],
+  ["--video-codec", "videoCodec"],
+  ["--pdf-action", "pdfAction"],
+  ["--password", "password"]
+]);
+
+const HELP = `FlyingMouse Format CLI
+
+Usage:
+  flyingmouse-format capabilities [--json]
+  flyingmouse-format targets <file-or-extension> [--json]
+  flyingmouse-format convert <files...> --to <format> [options]
+  flyingmouse-format images-to-pdf <images...> [--output <file>] [--json]
+  flyingmouse-format merge-pdfs <pdfs...> [--output <file>] [--json]
+
+Options:
+  --output <file>             Single-result output path
+  --output-dir <directory>    Output directory for one or more results
+  --compression-level <0-9>   ZIP compression level
+  --video-codec <h264|h265|av1>
+  --pdf-action <encrypt|decrypt>
+  --password <password>       PDF password (never printed in JSON output)
+  --json                      Stable machine-readable output
+  -h, --help                  Show this help
+
+Packaged app:
+  macOS: "FlyingMouse Format.app/Contents/MacOS/FlyingMouse Format" --cli ...
+  Windows: "FlyingMouse Format.exe" --cli ...
+`;
+
+function parseCliArgs(argv) {
+  const args = [...argv];
+  const command = args.shift() || "help";
+  const files = [];
+  const options = { json: false, help: false };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (VALUE_OPTIONS.has(arg)) {
+      const value = args[index + 1];
+      if (value == null || value.startsWith("--")) throw new Error(`${arg} requires a value.`);
+      options[VALUE_OPTIONS.get(arg)] = value;
+      index += 1;
+    } else if (arg.startsWith("--")) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      files.push(arg);
+    }
+  }
+
+  return { command, files, options };
+}
+
+function uniqueDestination(filePath) {
+  if (!fs.existsSync(filePath)) return filePath;
+  const parsed = path.parse(filePath);
+  let counter = 1;
+  let candidate;
+  do {
+    candidate = path.join(parsed.dir, `${parsed.name} (${counter})${parsed.ext}`);
+    counter += 1;
+  } while (fs.existsSync(candidate));
+  return candidate;
+}
+
+function resolveOutputDestinations(results, options = {}) {
+  if (options.output && results.length !== 1) {
+    throw new Error("--output can only be used for one result; use --output-dir for multiple files.");
+  }
+  if (options.output && options.outputDir) throw new Error("Use either --output or --output-dir, not both.");
+  if (options.output) return [path.resolve(options.output)];
+  const directory = path.resolve(options.outputDir || process.cwd());
+  const reserved = new Set();
+  return results.map((result) => {
+    const initial = path.join(directory, path.basename(result.fileName));
+    let destination = uniqueDestination(initial);
+    if (reserved.has(destination)) {
+      const parsed = path.parse(destination);
+      let counter = 1;
+      do {
+        destination = uniqueDestination(path.join(parsed.dir, `${parsed.name} (${counter})${parsed.ext}`));
+        counter += 1;
+      } while (reserved.has(destination));
+    }
+    reserved.add(destination);
+    return destination;
+  });
+}
+
+function sanitizeJsonError(error, options = {}) {
+  const password = String(options.password || "");
+  let message = String(error?.message || error || "Unknown error");
+  if (password) message = message.split(password).join("[redacted]");
+  return {
+    ok: false,
+    error: message,
+    errorCode: error?.errorCode || "CLI_FAILED"
+  };
+}
+
+function requestJson(url, requestOptions = {}, body) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const request = http.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: `${parsed.pathname}${parsed.search}`,
+      method: requestOptions.method || "GET",
+      headers: requestOptions.headers || {}
+    }, (response) => {
+      const chunks = [];
+      response.on("data", (chunk) => chunks.push(chunk));
+      response.on("end", () => {
+        let payload;
+        try {
+          payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        } catch {
+          payload = { error: Buffer.concat(chunks).toString("utf8") || `HTTP ${response.statusCode}` };
+        }
+        if ((response.statusCode || 500) >= 400) {
+          const error = new Error(payload.messages?.zhCN || payload.error || `HTTP ${response.statusCode}`);
+          error.errorCode = payload.errorCode;
+          error.payload = payload;
+          reject(error);
+          return;
+        }
+        resolve(payload);
+      });
+    });
+    request.on("error", reject);
+    if (body) request.write(body);
+    request.end();
+  });
+}
+
+async function writeRequestChunk(request, chunk) {
+  if (request.write(chunk)) return;
+  await new Promise((resolve) => request.once("drain", resolve));
+}
+
+async function postMultipart(url, fields, files, fieldName) {
+  const boundary = `----flyingmouse-${randomUUID()}`;
+  const parts = [];
+  for (const [name, value] of Object.entries(fields)) {
+    if (value == null || value === "") continue;
+    parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="${name}"\r\n\r\n${String(value)}\r\n`));
+  }
+  const fileParts = [];
+  for (const filePath of files) {
+    const absolute = path.resolve(filePath);
+    const stat = await fsp.stat(absolute);
+    if (!stat.isFile()) throw new Error(`Not a file: ${filePath}`);
+    const safeName = path.basename(absolute).replace(/["\r\n]/g, "_");
+    const header = Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="${fieldName}"; filename="${safeName}"\r\nContent-Type: application/octet-stream\r\n\r\n`);
+    fileParts.push({ absolute, header, size: stat.size });
+  }
+  const closing = Buffer.from(`--${boundary}--\r\n`);
+  const contentLength = parts.reduce((sum, item) => sum + item.length, 0)
+    + fileParts.reduce((sum, item) => sum + item.header.length + item.size + 2, 0)
+    + closing.length;
+
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const request = http.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname,
+      method: "POST",
+      headers: {
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+        "Content-Length": contentLength
+      }
+    }, (response) => {
+      const chunks = [];
+      response.on("data", (chunk) => chunks.push(chunk));
+      response.on("end", () => {
+        let payload;
+        try { payload = JSON.parse(Buffer.concat(chunks).toString("utf8")); }
+        catch { payload = { error: Buffer.concat(chunks).toString("utf8") }; }
+        if ((response.statusCode || 500) >= 400) {
+          const error = new Error(payload.messages?.zhCN || payload.error || `HTTP ${response.statusCode}`);
+          error.errorCode = payload.errorCode;
+          error.payload = payload;
+          reject(error);
+        } else resolve(payload);
+      });
+    });
+    request.on("error", reject);
+    (async () => {
+      try {
+        for (const part of parts) await writeRequestChunk(request, part);
+        for (const item of fileParts) {
+          await writeRequestChunk(request, item.header);
+          for await (const chunk of fs.createReadStream(item.absolute)) await writeRequestChunk(request, chunk);
+          await writeRequestChunk(request, Buffer.from("\r\n"));
+        }
+        request.end(closing);
+      } catch (error) {
+        request.destroy(error);
+      }
+    })();
+  });
+}
+
+async function downloadFile(url, destination) {
+  await fsp.mkdir(path.dirname(destination), { recursive: true });
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const request = http.get(parsed, (response) => {
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`Download failed with HTTP ${response.statusCode}.`));
+        return;
+      }
+      const output = fs.createWriteStream(destination, { flags: "wx" });
+      response.pipe(output);
+      output.on("finish", () => output.close(resolve));
+      output.on("error", reject);
+    });
+    request.on("error", reject);
+  });
+}
+
+function extensionFromInput(value) {
+  const base = path.basename(String(value || ""));
+  const ext = path.extname(base).replace(/^\./, "");
+  return ext || base.replace(/^\./, "");
+}
+
+function printResult(payload, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  if (Array.isArray(payload.outputs)) {
+    for (const output of payload.outputs) process.stdout.write(`${output.path}\n`);
+  } else {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  }
+}
+
+async function executeCli(parsed, runtime) {
+  if (parsed.command === "help" || parsed.options.help) return { help: true };
+  const { startServer } = runtime || require("./server");
+  const started = await startServer(0);
+  try {
+    const baseUrl = started.url;
+    if (parsed.command === "capabilities") {
+      return await requestJson(`${baseUrl}/api/capabilities`);
+    }
+    if (parsed.command === "targets") {
+      if (parsed.files.length !== 1) throw new Error("targets requires one file name or extension.");
+      return await requestJson(`${baseUrl}/api/targets`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" }
+      }, JSON.stringify({ extension: extensionFromInput(parsed.files[0]) }));
+    }
+    if (!parsed.files.length) throw new Error(`${parsed.command} requires at least one input file.`);
+
+    let results;
+    if (parsed.command === "convert") {
+      if (!parsed.options.to) throw new Error("convert requires --to <format>.");
+      results = [];
+      for (const file of parsed.files) {
+        results.push(await postMultipart(`${baseUrl}/api/convert`, {
+          targetFormat: parsed.options.to,
+          compressionLevel: parsed.options.compressionLevel,
+          videoCodec: parsed.options.videoCodec,
+          pdfAction: parsed.options.pdfAction,
+          password: parsed.options.password
+        }, [file], "file"));
+      }
+    } else if (parsed.command === "images-to-pdf") {
+      results = [await postMultipart(`${baseUrl}/api/convert-images-to-pdf`, {}, parsed.files, "files")];
+    } else if (parsed.command === "merge-pdfs") {
+      results = [await postMultipart(`${baseUrl}/api/merge-pdfs`, {}, parsed.files, "files")];
+    } else {
+      throw new Error(`Unknown command: ${parsed.command}`);
+    }
+
+    const destinations = resolveOutputDestinations(results, parsed.options);
+    const outputs = [];
+    for (let index = 0; index < results.length; index += 1) {
+      await downloadFile(new URL(results[index].downloadUrl, baseUrl), destinations[index]);
+      outputs.push({
+        input: parsed.command === "convert" ? path.resolve(parsed.files[index]) : parsed.files.map((item) => path.resolve(item)),
+        path: destinations[index],
+        fileName: results[index].fileName,
+        mimeType: results[index].mimeType,
+        warnings: results[index].warnings || []
+      });
+    }
+    return { ok: true, command: parsed.command, outputs };
+  } finally {
+    await new Promise((resolve) => started.server.close(resolve));
+  }
+}
+
+async function runCli(argv = process.argv.slice(2), runtime) {
+  process.env.FLYINGMOUSE_LOG_STDERR = "1";
+  let parsed;
+  try {
+    parsed = parseCliArgs(argv);
+    const result = await executeCli(parsed, runtime);
+    if (result.help) process.stdout.write(HELP);
+    else printResult(result, parsed.options.json);
+    return 0;
+  } catch (error) {
+    const payload = sanitizeJsonError(error, parsed?.options || {});
+    if (parsed?.options?.json) process.stderr.write(`${JSON.stringify(payload)}\n`);
+    else process.stderr.write(`Error: ${payload.error}\nRun with --help for usage.\n`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => { process.exitCode = code; });
+}
+
+module.exports = {
+  HELP,
+  parseCliArgs,
+  resolveOutputDestinations,
+  sanitizeJsonError,
+  executeCli,
+  runCli
+};

--- a/electron-main.js
+++ b/electron-main.js
@@ -11,6 +11,7 @@ const {
 } = require("./electron-security");
 const logger = require("./logger");
 const { buildDiagnosticsReport } = require("./diagnostics");
+const { discoverSkillRoots, installAgentSkill } = require("./agent-skill-installer");
 const { resolveRuntimePaths } = require("./runtime-paths");
 const {
   mergeLegacySettings,
@@ -25,6 +26,8 @@ let server = null;
 let serverUrl = "";
 let serverRuntime = null;
 const settingsPath = path.join(app.getPath("userData"), "settings.json");
+const cliMarkerIndex = process.argv.indexOf("--cli");
+const cliMode = cliMarkerIndex >= 0;
 
 // Route all logging (including from server.js and renderer-forwarded IPC
 // messages) to a single debug.log in the Electron userData directory.
@@ -140,8 +143,7 @@ ipcMain.handle("check-for-updates", async (event) => {
   }
 });
 
-async function boot() {
-  log("Boot started");
+function configureRuntime() {
   process.env.FLYINGMOUSE_RUNTIME_DIR = path.join(os.tmpdir(), "flyingmouse-format-runtime");
   const runtimePaths = resolveRuntimePaths({ resourcesPath: process.resourcesPath });
   process.env.FLYINGMOUSE_FFMPEG_PATH = runtimePaths.ffmpeg;
@@ -155,6 +157,11 @@ async function boot() {
   log(`AV3A decoder path: ${process.env.FLYINGMOUSE_AVS3_DECODER_PATH || "unavailable"}`);
   log(`LibreOffice path: ${process.env.FLYINGMOUSE_LIBREOFFICE_PATH}`);
   log(`Poppler path: ${process.env.FLYINGMOUSE_PDFTOPPM_PATH}`);
+}
+
+async function boot() {
+  log("Boot started");
+  configureRuntime();
   serverRuntime = require("./server");
 
   const started = await serverRuntime.startServer(0);
@@ -165,6 +172,49 @@ async function boot() {
   setupAutoUpdater();
   createWindow(started.url);
 }
+
+function bundledSkillSource() {
+  return path.join(app.getAppPath(), "agent-skill", "flyingmouse-format");
+}
+
+function currentCliLauncher() {
+  return {
+    executable: process.execPath,
+    args: app.isPackaged ? [] : [app.getAppPath()]
+  };
+}
+
+ipcMain.handle("inspect-agent-skill-targets", async (event) => {
+  assertTrustedIpc(event);
+  const targets = await discoverSkillRoots();
+  return { targets };
+});
+
+ipcMain.handle("install-agent-skill", async (event, payload) => {
+  assertTrustedIpc(event);
+  const discovered = await discoverSkillRoots();
+  const requested = new Set(Array.isArray(payload?.targetIds) ? payload.targetIds.map(String) : []);
+  const roots = discovered.filter((item) => requested.has(item.id));
+  if (!roots.length) return { canceled: false, installed: [], failed: [] };
+
+  const targetNames = roots.map((item) => `${item.name}: ${item.path}`).join("\n");
+  const confirmation = await dialog.showMessageBox(mainWindow, {
+    type: "question",
+    buttons: ["接入 / Connect", "取消 / Cancel"],
+    defaultId: 0,
+    cancelId: 1,
+    title: "接入 Agent / Connect to Agent",
+    message: "将安装或更新 FlyingMouse Format skill",
+    detail: `应用会把轻量 skill 写入以下已存在的目录，并记录当前程序的 CLI 路径：\n\n${targetNames}`,
+    noLink: true
+  });
+  if (confirmation.response !== 0) return { canceled: true };
+  return installAgentSkill({
+    sourceDir: bundledSkillSource(),
+    roots,
+    launcher: currentCliLauncher()
+  });
+});
 
 function downloadToFile(url, destination) {
   const client = url.startsWith("https:") ? https : http;
@@ -366,13 +416,27 @@ if (process.platform === "win32") {
 process.on("uncaughtException", (error) => log("Uncaught exception", error));
 process.on("unhandledRejection", (error) => log("Unhandled rejection", error));
 
-app.whenReady().then(boot).catch((error) => {
-  log("Boot failed", error);
-  console.error(error);
-  app.quit();
-});
+if (cliMode) {
+  app.whenReady().then(async () => {
+    configureRuntime();
+    const { runCli } = require("./cli");
+    const code = await runCli(process.argv.slice(cliMarkerIndex + 1));
+    app.exit(code);
+  }).catch((error) => {
+    log("CLI boot failed", error);
+    console.error(error);
+    app.exit(1);
+  });
+} else {
+  app.whenReady().then(boot).catch((error) => {
+    log("Boot failed", error);
+    console.error(error);
+    app.quit();
+  });
+}
 
 app.on("window-all-closed", () => {
+  if (cliMode) return;
   log("All windows closed");
   if (process.platform !== "darwin") {
     app.quit();
@@ -380,7 +444,7 @@ app.on("window-all-closed", () => {
 });
 
 app.on("activate", () => {
-  if (!mainWindow && server?.listening) {
+  if (!cliMode && !mainWindow && server?.listening) {
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : 5177;
     serverUrl = `http://127.0.0.1:${port}`;
@@ -389,6 +453,7 @@ app.on("activate", () => {
 });
 
 app.on("before-quit", () => {
+  if (cliMode) return;
   log("Before quit");
   if (server?.listening) {
     server.close();
@@ -396,6 +461,7 @@ app.on("before-quit", () => {
 });
 
 app.on("web-contents-created", (_event, contents) => {
+  if (cliMode) return;
   contents.setWindowOpenHandler(({ url }) => {
     if (isAllowedExternalUrl(url)) {
       setImmediate(() => {

--- a/logger.js
+++ b/logger.js
@@ -105,7 +105,8 @@ function write(level, message, error) {
     trimIfOversized(filePath);
     // Also mirror to stdout so `node server.js` sessions stay observable.
     if (LEVELS[level] >= LEVELS.WARN) {
-      process.stdout.write(`[${level}] ${message}${formatError(error)}\n`);
+      const stream = process.env.FLYINGMOUSE_LOG_STDERR === "1" ? process.stderr : process.stdout;
+      stream.write(`[${level}] ${message}${formatError(error)}\n`);
     }
   } catch {
     // Never let logging take down the app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "yauzl": "^2.10.0",
         "yazl": "^3.3.1"
       },
+      "bin": {
+        "flyingmouse-format": "cli.js"
+      },
       "devDependencies": {
         "electron": "^43.1.0",
         "electron-builder": "^26.15.3"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "description": "Windows desktop universal file format converter (offline, bundled FFmpeg/LibreOffice/Poppler/Tesseract).",
   "main": "electron-main.js",
+  "bin": {
+    "flyingmouse-format": "cli.js"
+  },
   "scripts": {
     "start": "node server.js",
     "desktop": "electron .",
@@ -16,8 +19,8 @@
     "dist:mac:arm64": "node scripts/validate-ci-engines.js --platform darwin --arch arm64 --root bin/engines/darwin-arm64 && electron-builder --mac dmg --arm64 --publish never",
     "dist:mac:x64": "node scripts/validate-ci-engines.js --platform darwin --arch x64 --root bin/engines/darwin-x64 && electron-builder --mac dmg --x64 --publish never",
     "dist:win7": "node scripts/build-win7.js",
-    "test": "node --test tests/runtime-paths.test.js tests/raw-input.test.js tests/macos-packaging.test.js tests/image-conversion.test.js tests/av3a-format.test.js tests/ncm-metadata.test.js tests/ci-engine-release.test.js tests/conversion-preferences.test.js tests/i18n.test.js tests/settings-store.test.js tests/office-engine.test.js tests/office-quality.test.js tests/office-wps-repair.test.js tests/diagnostics.test.js tests/conversion.test.js tests/electron-hardening-static.test.js tests/electron-security.test.js tests/logger.test.js tests/mouse-assets.test.js tests/pdf-table-extractor.test.js tests/pdf-table-runtime.test.js tests/resource-policy.test.js tests/text-conversion.test.js tests/text-conversion-integration.test.js tests/ui-static.test.js tests/win7-build-profile.test.js tests/win7-build-script.test.js tests/pe-metadata.test.js tests/bmp-input.test.js tests/xml-json.test.js tests/mflac-format.test.js tests/kgma-format.test.js tests/media-codec.test.js tests/pdf2docx.test.js tests/ebook.test.js",
-    "test:ci": "node --test tests/runtime-paths.test.js tests/raw-input.test.js tests/macos-packaging.test.js tests/image-conversion.test.js tests/av3a-format.test.js tests/ncm-metadata.test.js tests/ci-engine-release.test.js tests/conversion-preferences.test.js tests/i18n.test.js tests/settings-store.test.js tests/office-engine.test.js tests/office-quality.test.js tests/office-wps-repair.test.js tests/diagnostics.test.js tests/electron-hardening-static.test.js tests/electron-security.test.js tests/logger.test.js tests/mouse-assets.test.js tests/pdf-table-extractor.test.js tests/pdf-table-runtime.test.js tests/resource-policy.test.js tests/text-conversion.test.js tests/text-conversion-integration.test.js tests/ui-static.test.js tests/win7-build-profile.test.js tests/win7-build-script.test.js tests/pe-metadata.test.js tests/bmp-input.test.js tests/xml-json.test.js tests/mflac-format.test.js tests/kgma-format.test.js tests/media-codec.test.js tests/pdf2docx.test.js tests/ebook.test.js"
+    "test": "node --test tests/runtime-paths.test.js tests/raw-input.test.js tests/macos-packaging.test.js tests/image-conversion.test.js tests/av3a-format.test.js tests/ncm-metadata.test.js tests/ci-engine-release.test.js tests/conversion-preferences.test.js tests/i18n.test.js tests/settings-store.test.js tests/office-engine.test.js tests/office-quality.test.js tests/office-wps-repair.test.js tests/diagnostics.test.js tests/conversion.test.js tests/electron-hardening-static.test.js tests/electron-security.test.js tests/logger.test.js tests/mouse-assets.test.js tests/pdf-table-extractor.test.js tests/pdf-table-runtime.test.js tests/resource-policy.test.js tests/text-conversion.test.js tests/text-conversion-integration.test.js tests/ui-static.test.js tests/preview.test.js tests/cli.test.js tests/agent-skill-installer.test.js tests/win7-build-profile.test.js tests/win7-build-script.test.js tests/pe-metadata.test.js tests/bmp-input.test.js tests/xml-json.test.js tests/mflac-format.test.js tests/kgma-format.test.js tests/media-codec.test.js tests/pdf2docx.test.js tests/ebook.test.js",
+    "test:ci": "node --test tests/runtime-paths.test.js tests/raw-input.test.js tests/macos-packaging.test.js tests/image-conversion.test.js tests/av3a-format.test.js tests/ncm-metadata.test.js tests/ci-engine-release.test.js tests/conversion-preferences.test.js tests/i18n.test.js tests/settings-store.test.js tests/office-engine.test.js tests/office-quality.test.js tests/office-wps-repair.test.js tests/diagnostics.test.js tests/electron-hardening-static.test.js tests/electron-security.test.js tests/logger.test.js tests/mouse-assets.test.js tests/pdf-table-extractor.test.js tests/pdf-table-runtime.test.js tests/resource-policy.test.js tests/text-conversion.test.js tests/text-conversion-integration.test.js tests/ui-static.test.js tests/preview.test.js tests/cli.test.js tests/agent-skill-installer.test.js tests/win7-build-profile.test.js tests/win7-build-script.test.js tests/pe-metadata.test.js tests/bmp-input.test.js tests/xml-json.test.js tests/mflac-format.test.js tests/kgma-format.test.js tests/media-codec.test.js tests/pdf2docx.test.js tests/ebook.test.js"
   },
   "dependencies": {
     "@tesseract.js-data/chi_sim": "^1.0.0",
@@ -65,6 +68,8 @@
     },
     "files": [
       "electron-main.js",
+      "cli.js",
+      "agent-skill-installer.js",
       "electron-security.js",
       "preload.js",
       "server.js",
@@ -101,6 +106,7 @@
       "text-docx.js",
       "office-convert.js",
       "public/**/*",
+      "agent-skill/**/*",
       "package.json",
       "node_modules/**/*"
     ],

--- a/preload.js
+++ b/preload.js
@@ -13,6 +13,12 @@ contextBridge.exposeInMainWorld("flyingMouseFormat", {
   exportDiagnostics() {
     return ipcRenderer.invoke("export-diagnostics");
   },
+  inspectAgentSkillTargets() {
+    return ipcRenderer.invoke("inspect-agent-skill-targets");
+  },
+  installAgentSkill(payload) {
+    return ipcRenderer.invoke("install-agent-skill", payload);
+  },
   saveConvertedFile(payload) {
     return ipcRenderer.invoke("save-converted-file", payload);
   },

--- a/public/app.js
+++ b/public/app.js
@@ -6,6 +6,8 @@ const state = {
   batchResults: [],
   isConverting: false,
   progressValue: 0,
+  previewResult: null,
+  previewOpener: null,
   settings: { schemaVersion: 2, targetBySource: {} }
 };
 
@@ -56,6 +58,13 @@ const clearButton = document.querySelector("#clearButton");
 const statusBox = document.querySelector("#statusBox");
 const downloadButton = document.querySelector("#downloadButton");
 const batchSaveButton = document.querySelector("#batchSaveButton");
+const previewButton = document.querySelector("#previewButton");
+const previewDrawer = document.querySelector("#previewDrawer");
+const previewBackdrop = document.querySelector("#previewBackdrop");
+const previewClose = document.querySelector("#previewClose");
+const previewTitle = document.querySelector("#previewTitle");
+const previewMeta = document.querySelector("#previewMeta");
+const previewContent = document.querySelector("#previewContent");
 const toolHealth = document.querySelector("#toolHealth");
 const formatTable = document.querySelector("#formatTable");
 const dropHint = document.querySelector("#dropHint");
@@ -68,6 +77,7 @@ const progressFill = document.querySelector("#progressFill");
 const mouseMascot = document.querySelector("#mouseMascot");
 const languageSelect = document.querySelector("#languageSelect");
 const diagnosticsButton = document.querySelector("#diagnosticsButton");
+const agentInstallButton = document.querySelector("#agentInstallButton");
 const workflowSteps = [...document.querySelectorAll("[data-step]")];
 const {
   STORAGE_KEY: LEGACY_TARGET_STORAGE_KEY,
@@ -83,6 +93,13 @@ const messages = {
     "language.label": "语言", "health.checking": "正在检测转换引擎", "health.failed": "检测失败",
     "diagnostics.export": "导出诊断", "diagnostics.saved": "诊断报告已保存到：{path}",
     "diagnostics.canceled": "已取消导出诊断报告。", "diagnostics.failed": "导出诊断失败：{message}",
+    "agent.install": "接入 Agent", "agent.checking": "正在检索已安装 Agent 的 skill 目录…",
+    "agent.none": "没有发现现有的 Agent skill 目录。请先安装 Codex、Claude 或创建 ~/.agents/skills。",
+    "agent.canceled": "已取消接入 Agent。", "agent.installed": "已接入 {count} 个 Agent：{paths}",
+    "agent.partial": "已接入 {count} 个 Agent，另有 {failed} 个失败：{message}", "agent.failed": "接入 Agent 失败：{message}",
+    "preview.open": "预览", "preview.eyebrow": "转换结果", "preview.title": "文件预览",
+    "preview.close": "关闭预览", "preview.loading": "正在载入预览…", "preview.unsupported": "此格式暂不支持内嵌预览，可以保存后使用系统应用打开。",
+    "preview.tooLarge": "文本文件超过 2 MB，为避免界面卡顿，请保存后查看。", "preview.failed": "预览失败：{message}",
     "update.check": "检查更新", "update.checking": "正在检查更新…",
     "update.latest": "已是最新版本", "update.available": "发现新版本 v{version}，正在下载…",
     "update.downloaded": "新版本 v{version} 已下载，重启后生效", "update.restart": "立即重启",
@@ -148,6 +165,13 @@ const messages = {
     "language.label": "Language", "health.checking": "Checking conversion engines", "health.failed": "Check failed",
     "diagnostics.export": "Export diagnostics", "diagnostics.saved": "Diagnostics saved to: {path}",
     "diagnostics.canceled": "Diagnostics export canceled.", "diagnostics.failed": "Diagnostics export failed: {message}",
+    "agent.install": "Connect to Agent", "agent.checking": "Looking for existing Agent skill directories…",
+    "agent.none": "No existing Agent skill directory was found. Install Codex or Claude, or create ~/.agents/skills first.",
+    "agent.canceled": "Agent connection canceled.", "agent.installed": "Connected to {count} Agent target(s): {paths}",
+    "agent.partial": "Connected to {count} target(s); {failed} failed: {message}", "agent.failed": "Agent connection failed: {message}",
+    "preview.open": "Preview", "preview.eyebrow": "Conversion result", "preview.title": "File preview",
+    "preview.close": "Close preview", "preview.loading": "Loading preview…", "preview.unsupported": "This format cannot be previewed here. Save it and open it with a system application.",
+    "preview.tooLarge": "This text file is larger than 2 MB. Save it to view without slowing the app.", "preview.failed": "Preview failed: {message}",
     "update.check": "Check for Updates", "update.checking": "Checking for updates…",
     "update.latest": "You are up to date", "update.available": "New version v{version} found, downloading…",
     "update.downloaded": "v{version} downloaded; restart to apply", "update.restart": "Restart now",
@@ -363,6 +387,8 @@ function resetDownload() {
   downloadButton.removeAttribute("href");
   downloadButton.removeAttribute("download");
   batchSaveButton.hidden = true;
+  previewButton.hidden = true;
+  closePreview();
 }
 
 function clearFile() {
@@ -516,6 +542,10 @@ function renderBatchList() {
     }
     actions.append(createTextElement("span", "batch-status", batchStatusLabel(result.status)));
     if (result.status === "success" && result.result) {
+      const resultPreviewButton = createTextElement("button", "mini-button", t("preview.open"));
+      resultPreviewButton.type = "button";
+      resultPreviewButton.dataset.previewIndex = String(index);
+      actions.append(resultPreviewButton);
       const saveButton = createTextElement("button", "mini-button", t("action.save"));
       saveButton.type = "button";
       saveButton.dataset.saveIndex = String(index);
@@ -783,6 +813,7 @@ async function convertMergedImagesToPdf() {
     downloadButton.download = result.fileName;
     downloadButton.textContent = `${t("action.save")} ${result.fileName}`;
     downloadButton.hidden = false;
+    previewButton.hidden = false;
     batchSaveButton.hidden = true;
     setProgress(100, i18n.language === "en-US" ? "Merge complete" : "合并完成", "success");
     setStatus(i18n.language === "en-US" ? `Images merged into ${result.fileName}.` : `图片已合并为：${result.fileName}。`, "success");
@@ -855,6 +886,7 @@ async function convertMergedPdfs() {
     downloadButton.download = result.fileName;
     downloadButton.textContent = `${t("action.save")} ${result.fileName}`;
     downloadButton.hidden = false;
+    previewButton.hidden = false;
     batchSaveButton.hidden = true;
     setProgress(100, i18n.language === "en-US" ? "Merge complete" : "合并完成", "success");
     setStatus(i18n.language === "en-US" ? `PDF files merged into ${result.fileName}.` : `PDF 已合并为：${result.fileName}。`, "success");
@@ -948,6 +980,7 @@ async function convertCurrentFiles() {
     downloadButton.download = successful[0].result.fileName;
     downloadButton.textContent = `${t("action.save")} ${successful[0].result.fileName}`;
     downloadButton.hidden = false;
+    previewButton.hidden = false;
   }
 
   batchSaveButton.hidden = successful.length < 2;
@@ -986,6 +1019,94 @@ async function saveResult(result) {
   link.href = result.downloadUrl;
   link.download = result.fileName;
   link.click();
+}
+
+function previewFallback(result, message) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "preview-fallback";
+  wrapper.append(
+    createTextElement("p", "preview-fallback-name", result.fileName),
+    createTextElement("p", "", message),
+    createTextElement("p", "preview-fallback-meta", `${result.mimeType || "application/octet-stream"} · ${formatSize(result.previewSize || 0)}`)
+  );
+  previewContent.replaceChildren(wrapper);
+}
+
+async function renderPreview(result) {
+  previewTitle.textContent = result.fileName || t("preview.title");
+  previewMeta.textContent = `${result.mimeType || "application/octet-stream"} · ${formatSize(result.previewSize || 0)}`;
+  previewContent.replaceChildren(createTextElement("p", "preview-loading", t("preview.loading")));
+  const previewKind = result.previewKind;
+  if (!result.previewUrl || previewKind === "unsupported") {
+    previewFallback(result, t("preview.unsupported"));
+    return;
+  }
+  if (previewKind === "image") {
+    const image = document.createElement("img");
+    image.className = "preview-image";
+    image.alt = result.fileName;
+    image.src = result.previewUrl;
+    previewContent.replaceChildren(image);
+    return;
+  }
+  if (previewKind === "pdf") {
+    const frame = document.createElement("iframe");
+    frame.className = "preview-frame";
+    frame.title = result.fileName;
+    frame.src = result.previewUrl;
+    previewContent.replaceChildren(frame);
+    return;
+  }
+  if (previewKind === "audio" || previewKind === "video") {
+    const media = document.createElement(previewKind);
+    media.className = `preview-${previewKind}`;
+    media.controls = true;
+    media.preload = "metadata";
+    media.src = result.previewUrl;
+    previewContent.replaceChildren(media);
+    return;
+  }
+  if (previewKind === "text") {
+    if ((result.previewSize || 0) > 2 * 1024 * 1024) {
+      previewFallback(result, t("preview.tooLarge"));
+      return;
+    }
+    const response = await fetch(result.previewUrl);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const pre = document.createElement("pre");
+    pre.className = "preview-text";
+    pre.textContent = await response.text();
+    previewContent.replaceChildren(pre);
+    return;
+  }
+  previewFallback(result, t("preview.unsupported"));
+}
+
+async function openPreview(result, opener) {
+  if (!result) return;
+  state.previewResult = result;
+  state.previewOpener = opener || document.activeElement;
+  previewDrawer.hidden = false;
+  previewBackdrop.hidden = false;
+  document.body.classList.add("preview-open");
+  previewClose.focus();
+  try {
+    await renderPreview(result);
+  } catch (error) {
+    previewFallback(result, t("preview.failed", { message: error.message || "unknown" }));
+  }
+}
+
+function closePreview() {
+  if (!previewDrawer || previewDrawer.hidden) return;
+  previewDrawer.hidden = true;
+  previewBackdrop.hidden = true;
+  previewContent.replaceChildren();
+  document.body.classList.remove("preview-open");
+  const opener = state.previewOpener;
+  state.previewResult = null;
+  state.previewOpener = null;
+  if (opener && document.contains(opener)) opener.focus();
 }
 
 async function saveConvertedFile(event) {
@@ -1057,6 +1178,12 @@ batchList.addEventListener("click", async (event) => {
     moveFileInQueue(Number(moveButton.dataset.move), moveButton.dataset.direction);
     return;
   }
+  const previewAction = event.target.closest("[data-preview-index]");
+  if (previewAction) {
+    const result = state.batchResults[Number(previewAction.dataset.previewIndex)]?.result;
+    await openPreview(result, previewAction);
+    return;
+  }
   const button = event.target.closest("[data-save-index]");
   if (!button) return;
   const index = Number(button.dataset.saveIndex);
@@ -1096,6 +1223,43 @@ targetSelect.addEventListener("change", async () => {
 });
 downloadButton.addEventListener("click", saveConvertedFile);
 batchSaveButton.addEventListener("click", saveAllConvertedFiles);
+previewButton.addEventListener("click", () => openPreview(state.converted, previewButton));
+previewClose.addEventListener("click", closePreview);
+previewBackdrop.addEventListener("click", closePreview);
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && !previewDrawer.hidden) closePreview();
+});
+agentInstallButton.addEventListener("click", async () => {
+  if (typeof logBridge.inspectAgentSkillTargets !== "function" || typeof logBridge.installAgentSkill !== "function") return;
+  agentInstallButton.disabled = true;
+  setStatus(t("agent.checking"));
+  try {
+    const inspected = await logBridge.inspectAgentSkillTargets();
+    if (!inspected?.targets?.length) {
+      setStatus(t("agent.none"));
+      return;
+    }
+    const result = await logBridge.installAgentSkill({ targetIds: inspected.targets.map((item) => item.id) });
+    if (result?.canceled) {
+      setStatus(t("agent.canceled"));
+    } else if (result.failed?.length) {
+      setStatus(t("agent.partial", {
+        count: result.installed.length,
+        failed: result.failed.length,
+        message: result.failed.map((item) => item.error).join("；")
+      }), result.installed.length ? "success" : "error");
+    } else {
+      setStatus(t("agent.installed", {
+        count: result.installed.length,
+        paths: result.installed.map((item) => item.path).join("；")
+      }), "success");
+    }
+  } catch (error) {
+    setStatus(t("agent.failed", { message: error.message || "unknown" }), "error");
+  } finally {
+    agentInstallButton.disabled = false;
+  }
+});
 diagnosticsButton.addEventListener("click", async () => {
   if (typeof logBridge.exportDiagnostics !== "function") return;
   diagnosticsButton.disabled = true;

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
             </div>
           </div>
           <div class="topbar-actions">
+            <button class="ghost-button diagnostics-button" id="agentInstallButton" type="button" data-i18n="agent.install">接入 Agent</button>
             <button class="ghost-button diagnostics-button" id="diagnosticsButton" type="button" data-i18n="diagnostics.export">导出诊断</button>
             <button class="ghost-button" id="updateButton" type="button" data-i18n="update.check" hidden>检查更新</button>
             <span class="update-status" id="updateStatus" hidden></span>
@@ -118,6 +119,7 @@
             </div>
 
             <div class="status-box" id="statusBox" role="status" data-i18n="status.ready">选择文件后会显示可用的转换格式。</div>
+            <button class="ghost-button preview-button" id="previewButton" type="button" hidden data-i18n="preview.open">预览</button>
             <a class="download-button" id="downloadButton" hidden data-i18n="action.download">下载转换后的文件</a>
             <button class="download-button" id="batchSaveButton" type="button" hidden data-i18n="action.saveAll">保存全部</button>
           </aside>
@@ -132,6 +134,19 @@
         </section>
       </section>
     </main>
+
+    <div class="preview-backdrop" id="previewBackdrop" hidden></div>
+    <aside class="preview-drawer" id="previewDrawer" hidden aria-labelledby="previewTitle" aria-modal="true" role="dialog">
+      <div class="preview-header">
+        <div>
+          <p class="eyebrow" data-i18n="preview.eyebrow">转换结果</p>
+          <h2 id="previewTitle" data-i18n="preview.title">文件预览</h2>
+          <p class="preview-meta" id="previewMeta"></p>
+        </div>
+        <button class="ghost-button preview-close" id="previewClose" type="button" data-i18n-aria="preview.close" aria-label="关闭预览">×</button>
+      </div>
+      <div class="preview-content" id="previewContent"></div>
+    </aside>
 
     <aside class="sponsor-widget" id="sponsorWidget" data-i18n-aria="sponsor.aria" aria-label="支持鼠鼠">
       <button class="sponsor-toggle" id="sponsorToggle" type="button" data-i18n-title="sponsor.aria" title="支持鼠鼠" aria-expanded="false">

--- a/public/styles.css
+++ b/public/styles.css
@@ -481,6 +481,19 @@ select {
   color: var(--muted);
 }
 
+button:focus-visible,
+a:focus-visible,
+select:focus-visible,
+input:focus-visible {
+  outline: 3px solid #3976d8;
+  outline-offset: 3px;
+}
+
+.preview-button {
+  color: var(--ink);
+  background: var(--blue-soft);
+}
+
 .progress-panel {
   display: grid;
   gap: 8px;
@@ -549,6 +562,140 @@ select {
 .status-box.success {
   color: var(--success);
   background: var(--green-soft);
+}
+
+.preview-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 170;
+  background: rgba(17, 17, 17, 0.36);
+  animation: preview-fade-in 180ms ease-out;
+}
+
+.preview-drawer {
+  position: fixed;
+  z-index: 180;
+  top: 0;
+  right: 0;
+  width: min(520px, calc(100vw - 48px));
+  height: 100vh;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: var(--panel);
+  border-left: 2px solid var(--line);
+  box-shadow: -8px 0 0 rgba(17, 17, 17, 0.22);
+  animation: preview-slide-in 220ms ease-out;
+}
+
+.preview-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px;
+  border-bottom: 2px solid var(--line);
+  background: linear-gradient(145deg, #fffdf8, var(--accent-soft));
+}
+
+.preview-header h2 {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.preview-meta {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.preview-close {
+  flex: none;
+  width: 42px;
+  min-height: 42px;
+  padding: 0;
+  color: var(--ink);
+  font-size: 24px;
+}
+
+.preview-content {
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  overflow: auto;
+  padding: 18px;
+  background: #f1eee7;
+}
+
+.preview-image {
+  display: block;
+  max-width: 100%;
+  max-height: calc(100vh - 150px);
+  object-fit: contain;
+  border: 2px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+}
+
+.preview-frame {
+  width: 100%;
+  height: 100%;
+  min-height: 420px;
+  border: 2px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+}
+
+.preview-audio,
+.preview-video {
+  width: 100%;
+  max-height: calc(100vh - 170px);
+}
+
+.preview-text {
+  align-self: stretch;
+  justify-self: stretch;
+  margin: 0;
+  min-height: 100%;
+  padding: 18px;
+  border: 2px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  color: var(--ink);
+  font: 13px/1.65 Consolas, "SFMono-Regular", "Courier New", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.preview-fallback {
+  width: min(360px, 100%);
+  border: 2px solid var(--line);
+  border-radius: var(--radius);
+  padding: 22px;
+  background: var(--card);
+  text-align: center;
+  box-shadow: 4px 4px 0 #111;
+}
+
+.preview-fallback-name {
+  font-weight: 900;
+  overflow-wrap: anywhere;
+}
+
+.preview-fallback-meta,
+.preview-loading {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+@keyframes preview-slide-in {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+
+@keyframes preview-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .matrix {
@@ -956,6 +1103,26 @@ select {
   .topbar-actions {
     justify-content: flex-start;
   }
+
+  .preview-drawer {
+    top: auto;
+    bottom: 0;
+    width: 100vw;
+    height: min(78vh, 720px);
+    border-top: 2px solid var(--line);
+    border-left: 0;
+    box-shadow: 0 -8px 0 rgba(17, 17, 17, 0.22);
+    animation-name: preview-sheet-in;
+  }
+
+  .preview-frame {
+    min-height: 300px;
+  }
+}
+
+@keyframes preview-sheet-in {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
 }
 
 @media (max-width: 520px) {
@@ -1013,5 +1180,16 @@ select {
   .batch-status {
     max-width: none;
     text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/server.js
+++ b/server.js
@@ -62,7 +62,7 @@ const {
   outputExtFor,
   outputNameFor,
   outputPathFor,
-  downloadUrlFor,
+  registerDownload,
   escapeHtml
 } = require("./utils");
 const { convertMedia, probeAudioTrack } = require("./media");
@@ -191,6 +191,8 @@ const CONTENT_SECURITY_POLICY = [
   "style-src 'self'",
   "img-src 'self' data:",
   "connect-src 'self'",
+  "frame-src 'self'",
+  "media-src 'self'",
   "object-src 'none'",
   "base-uri 'none'",
   "frame-ancestors 'none'",
@@ -387,12 +389,15 @@ app.post("/api/convert-images-to-pdf", assertLocalWebRequest, upload.array("file
     await Promise.all(files.map((file) => fsp.rm(file.path, { force: true }).catch(() => {})));
     const mimeType = "application/pdf";
     logger.info(`Images-to-PDF succeeded: "${downloadName}"`);
+    const registered = registerDownload(outputPath, downloadName, mimeType);
+    const previewSize = (await fsp.stat(outputPath)).size;
     res.json({
       ok: true,
       fileName: downloadName,
       category: "image",
       mimeType,
-      downloadUrl: downloadUrlFor(outputPath, downloadName, mimeType)
+      ...registered,
+      previewSize
     });
   } catch (error) {
     logger.error(`Images-to-PDF failed: "${combinedName}"`, error);
@@ -439,12 +444,16 @@ app.post("/api/merge-pdfs", assertLocalWebRequest, upload.array("files", 100), a
     await mergePdfFiles(pdfFiles, outputPath);
     await Promise.all(files.map((file) => fsp.rm(file.path, { force: true }).catch(() => {})));
     logger.info(`Merge-PDFs succeeded: "${downloadName}"`);
+    const mimeType = "application/pdf";
+    const registered = registerDownload(outputPath, downloadName, mimeType);
+    const previewSize = (await fsp.stat(outputPath)).size;
     res.json({
       ok: true,
       fileName: downloadName,
       category: "pdf",
-      mimeType: "application/pdf",
-      downloadUrl: downloadUrlFor(outputPath, downloadName, "application/pdf")
+      mimeType,
+      ...registered,
+      previewSize
     });
   } catch (error) {
     logger.error(`Merge-PDFs failed: "${combinedName}"`, error);
@@ -571,12 +580,15 @@ app.post("/api/convert", assertLocalWebRequest, upload.single("file"), async (re
 
     await fsp.rm(file.path, { force: true }).catch(() => {});
     const mimeType = mime.lookup(downloadName) || "application/octet-stream";
+    const registered = registerDownload(outputPath, downloadName, mimeType);
+    const previewSize = (await fsp.stat(outputPath)).size;
     const payload = {
       ok: true,
       fileName: downloadName,
       category,
       mimeType,
-      downloadUrl: downloadUrlFor(outputPath, downloadName, mimeType)
+      ...registered,
+      previewSize
     };
     if (Array.isArray(conversionResult?.warnings) && conversionResult.warnings.length) {
       payload.warnings = conversionResult.warnings;
@@ -639,6 +651,27 @@ app.get("/downloads/:id", (req, res) => {
   }
 
   res.download(item.filePath, item.downloadName, (error) => {
+    if (!error) return;
+    if (!res.headersSent) res.status(500).send(error.message);
+  });
+});
+
+app.get("/previews/:id", (req, res) => {
+  const item = downloads.get(req.params.id);
+  if (!item || !/^[A-Za-z0-9-]+$/.test(req.params.id) || req.originalUrl.includes("?")) {
+    res.status(404).send("File expired or not found.");
+    return;
+  }
+  const inlineName = encodeURIComponent(path.basename(item.downloadName)).replaceAll("'", "%27");
+  res.setHeader("Content-Type", item.mimeType || "application/octet-stream");
+  res.setHeader("Content-Disposition", `inline; filename="preview"; filename*=UTF-8''${inlineName}`);
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  if (String(item.mimeType).includes("html")) {
+    res.setHeader("Content-Security-Policy", "default-src 'none'; img-src data:; style-src 'unsafe-inline'; frame-ancestors 'self'; sandbox");
+  } else {
+    res.setHeader("Content-Security-Policy", "default-src 'none'; frame-ancestors 'self'");
+  }
+  res.sendFile(path.resolve(item.filePath), (error) => {
     if (!error) return;
     if (!res.headersSent) res.status(500).send(error.message);
   });

--- a/tests/agent-skill-installer.test.js
+++ b/tests/agent-skill-installer.test.js
@@ -1,0 +1,66 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+const {
+  discoverSkillRoots,
+  installAgentSkill
+} = require("../agent-skill-installer");
+
+test("discovers only existing Agent skill roots on macOS and Windows", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "flyingmouse-roots-"));
+  await fs.mkdir(path.join(home, ".codex", "skills"), { recursive: true });
+  await fs.mkdir(path.join(home, ".agents", "skills"), { recursive: true });
+  const roots = await discoverSkillRoots({ home, platform: "darwin", env: {} });
+  assert.deepEqual(roots.map((item) => item.id), ["codex", "agents"]);
+
+  const profile = await fs.mkdtemp(path.join(os.tmpdir(), "flyingmouse-win-roots-"));
+  await fs.mkdir(path.join(profile, ".claude", "skills"), { recursive: true });
+  const windowsRoots = await discoverSkillRoots({
+    home: profile,
+    platform: "win32",
+    env: { USERPROFILE: profile }
+  });
+  assert.deepEqual(windowsRoots.map((item) => item.id), ["claude"]);
+});
+
+test("installs the bundled skill atomically with a platform launcher config", async () => {
+  const temp = await fs.mkdtemp(path.join(os.tmpdir(), "flyingmouse-skill-install-"));
+  const source = path.join(temp, "source");
+  const root = path.join(temp, "skills");
+  await fs.mkdir(path.join(source, "scripts"), { recursive: true });
+  await fs.mkdir(root, { recursive: true });
+  await fs.writeFile(path.join(source, "SKILL.md"), "---\nname: flyingmouse-format\ndescription: test\n---\n");
+  await fs.writeFile(path.join(source, "scripts", "flyingmouse-format.js"), "// test\n");
+
+  const result = await installAgentSkill({
+    sourceDir: source,
+    roots: [{ id: "codex", name: "Codex", path: root }],
+    launcher: { executable: "/Applications/FlyingMouse Format.app/Contents/MacOS/FlyingMouse Format", args: [] }
+  });
+
+  assert.equal(result.installed.length, 1);
+  const installed = path.join(root, "flyingmouse-format");
+  const config = JSON.parse(await fs.readFile(path.join(installed, "launcher.json"), "utf8"));
+  assert.equal(config.executable, "/Applications/FlyingMouse Format.app/Contents/MacOS/FlyingMouse Format");
+  assert.equal(await fs.readFile(path.join(installed, "scripts", "flyingmouse-format.js"), "utf8"), "// test\n");
+});
+
+test("rejects a symlink skill root", async () => {
+  const temp = await fs.mkdtemp(path.join(os.tmpdir(), "flyingmouse-skill-link-"));
+  const actual = path.join(temp, "actual");
+  const linked = path.join(temp, "linked");
+  const source = path.join(temp, "source");
+  await fs.mkdir(actual);
+  await fs.mkdir(source);
+  await fs.writeFile(path.join(source, "SKILL.md"), "test");
+  await fs.mkdir(path.join(source, "scripts"));
+  await fs.writeFile(path.join(source, "scripts", "flyingmouse-format.js"), "test");
+  await fs.symlink(actual, linked, "dir");
+  await assert.rejects(() => installAgentSkill({
+    sourceDir: source,
+    roots: [{ id: "test", name: "Test", path: linked }],
+    launcher: { executable: process.execPath, args: [] }
+  }), /symbolic link/i);
+});

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,61 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { test } = require("node:test");
+const {
+  parseCliArgs,
+  resolveOutputDestinations,
+  sanitizeJsonError
+} = require("../cli");
+
+test("CLI parses conversion, merge, JSON, and engine options", () => {
+  const parsed = parseCliArgs([
+    "convert", "一.txt", "二.txt", "--to", "md", "--output-dir", "out",
+    "--compression-level", "9", "--video-codec", "h265", "--pdf-action", "decrypt",
+    "--password", "secret", "--json"
+  ]);
+  assert.equal(parsed.command, "convert");
+  assert.deepEqual(parsed.files, ["一.txt", "二.txt"]);
+  assert.equal(parsed.options.to, "md");
+  assert.equal(parsed.options.outputDir, "out");
+  assert.equal(parsed.options.compressionLevel, "9");
+  assert.equal(parsed.options.videoCodec, "h265");
+  assert.equal(parsed.options.pdfAction, "decrypt");
+  assert.equal(parsed.options.password, "secret");
+  assert.equal(parsed.options.json, true);
+});
+
+test("CLI preserves Chinese basenames and rejects ambiguous multi-file output", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "flyingmouse-cli-output-"));
+  const destinations = resolveOutputDestinations([
+    { fileName: "中文结果.md" },
+    { fileName: "第二个.md" }
+  ], { outputDir: dir });
+  assert.equal(destinations[0], path.join(dir, "中文结果.md"));
+  const duplicateDestinations = resolveOutputDestinations([
+    { fileName: "同名.md" }, { fileName: "同名.md" }
+  ], { outputDir: dir });
+  assert.notEqual(duplicateDestinations[0], duplicateDestinations[1]);
+  assert.throws(() => resolveOutputDestinations([
+    { fileName: "a.md" }, { fileName: "b.md" }
+  ], { output: path.join(dir, "one.md") }), /--output-dir/);
+});
+
+test("CLI JSON errors never include the PDF password", () => {
+  const payload = sanitizeJsonError(new Error("conversion failed: super-secret"), { password: "super-secret" });
+  assert.doesNotMatch(JSON.stringify(payload), /super-secret/);
+  assert.equal(payload.ok, false);
+});
+
+test("CLI keeps stdout as one parseable JSON value when engine probes warn", () => {
+  const result = spawnSync(process.execPath, [path.join(__dirname, "..", "cli.js"), "targets", "README.md", "--json"], {
+    cwd: path.join(__dirname, ".."),
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.extension, "md");
+  assert.doesNotMatch(result.stdout, /\[WARN\]/);
+});

--- a/tests/electron-hardening-static.test.js
+++ b/tests/electron-hardening-static.test.js
@@ -290,6 +290,30 @@ test("trusted IPC exports a sanitized diagnostics report to the remembered direc
   assert.match(preload, /ipcRenderer\.invoke\("export-diagnostics"/);
 });
 
+test("trusted IPC discovers and installs the bundled Agent skill", () => {
+  const packageJson = JSON.parse(readRoot("package.json"));
+  const main = readRoot("electron-main.js");
+  const preload = readRoot("preload.js");
+  assert.ok(packageJson.build.files.includes("agent-skill-installer.js"));
+  assert.ok(packageJson.build.files.includes("agent-skill/**/*"));
+  assert.match(main, /ipcMain\.handle\("inspect-agent-skill-targets"/);
+  assert.match(main, /ipcMain\.handle\("install-agent-skill"/);
+  assert.match(main, /assertTrustedIpc\(event\)/);
+  assert.match(main, /dialog\.showMessageBox/);
+  assert.match(preload, /ipcRenderer\.invoke\("inspect-agent-skill-targets"/);
+  assert.match(preload, /ipcRenderer\.invoke\("install-agent-skill"/);
+});
+
+test("packaged Electron exposes CLI mode without creating a window", () => {
+  const packageJson = JSON.parse(readRoot("package.json"));
+  const main = readRoot("electron-main.js");
+  assert.ok(packageJson.build.files.includes("cli.js"));
+  assert.strictEqual(packageJson.bin["flyingmouse-format"], "cli.js");
+  assert.match(main, /process\.argv\.indexOf\("--cli"\)/);
+  assert.match(main, /if \(cliMode\)[\s\S]*runCli/);
+  assert.match(main, /if \(!cliMode && !mainWindow/);
+});
+
 test("runtime diagnostics read Sharp's supported runtime version API", () => {
   const server = readRoot("server.js");
   assert.doesNotMatch(server, /require\(["']sharp\/package\.json["']\)/);

--- a/tests/preview.test.js
+++ b/tests/preview.test.js
@@ -1,0 +1,55 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+const { registerDownload } = require("../utils");
+const { downloads } = require("../config");
+
+const root = path.join(__dirname, "..");
+
+test("conversion results expose a registered inline preview without leaking paths", () => {
+  const server = fs.readFileSync(path.join(root, "server.js"), "utf8");
+  const utils = fs.readFileSync(path.join(root, "utils.js"), "utf8");
+  assert.match(server, /app\.get\("\/previews\/:id"/);
+  assert.match(server, /Content-Disposition",\s*`inline/);
+  assert.match(server, /X-Content-Type-Options",\s*"nosniff"/);
+  assert.match(server, /frame-ancestors 'self'/);
+  assert.match(utils, /previewUrl:\s*`\/previews\/\$\{id\}`/);
+  assert.doesNotMatch(server, /previewUrl[^\n]*filePath/);
+});
+
+test("preview UI supports a responsive drawer and safe renderer kinds", () => {
+  const html = fs.readFileSync(path.join(root, "public", "index.html"), "utf8");
+  const app = fs.readFileSync(path.join(root, "public", "app.js"), "utf8");
+  const css = fs.readFileSync(path.join(root, "public", "styles.css"), "utf8");
+  assert.match(html, /id="previewDrawer"/);
+  assert.match(html, /id="previewContent"/);
+  assert.match(app, /previewKind === "image"/);
+  assert.match(app, /previewKind === "pdf"/);
+  assert.match(app, /previewKind === "text"/);
+  assert.match(app, /previewKind === "audio"/);
+  assert.match(app, /previewKind === "video"/);
+  assert.match(app, /event\.key === "Escape"/);
+  assert.doesNotMatch(app, /\.innerHTML\s*=/);
+  assert.match(css, /\.preview-drawer/);
+  assert.match(css, /@media \(max-width: 860px\)[\s\S]*\.preview-drawer/);
+  assert.match(css, /prefers-reduced-motion/);
+});
+
+test("download registration assigns preview kinds without exposing a file path", () => {
+  const cases = [
+    ["picture.png", "image/png", "image"],
+    ["document.pdf", "application/pdf", "pdf"],
+    ["notes.md", "text/markdown", "text"],
+    ["sound.mp3", "audio/mpeg", "audio"],
+    ["movie.mp4", "video/mp4", "video"],
+    ["archive.zip", "application/zip", "unsupported"]
+  ];
+  for (const [name, mimeType, expected] of cases) {
+    const registered = registerDownload("/tmp/private-output", name, mimeType);
+    assert.equal(registered.previewKind, expected);
+    assert.doesNotMatch(JSON.stringify(registered), /private-output/);
+    const id = registered.downloadUrl.split("/").pop();
+    downloads.delete(id);
+  }
+});

--- a/tests/ui-static.test.js
+++ b/tests/ui-static.test.js
@@ -82,6 +82,17 @@ test("renderer exposes a bilingual diagnostics export through the trusted bridge
   assert.match(app, /error\.errorCode/);
 });
 
+test("renderer exposes Agent skill installation immediately before diagnostics", () => {
+  const html = readPublic("index.html");
+  const app = readPublic("app.js");
+  assert.match(html, /id="agentInstallButton"/);
+  assert.ok(html.indexOf('id="agentInstallButton"') < html.indexOf('id="diagnosticsButton"'));
+  assert.match(app, /"agent\.install": "接入 Agent"/);
+  assert.match(app, /"agent\.install": "Connect to Agent"/);
+  assert.match(app, /logBridge\.inspectAgentSkillTargets/);
+  assert.match(app, /logBridge\.installAgentSkill/);
+});
+
 test("PDF to XLSX uses a contextual bilingual smart-table label and warning", () => {
   const html = readPublic("index.html");
   const app = readPublic("app.js");

--- a/utils.js
+++ b/utils.js
@@ -223,7 +223,17 @@ function outputPathFor(originalName, targetExt, outputExt = targetExt) {
   return path.join(OUTPUT_DIR, `${Date.now()}-${randomUUID()}-${outputNameFor(originalName, targetExt, outputExt)}`);
 }
 
-function downloadUrlFor(filePath, downloadName, mimeType) {
+function previewKindFor(downloadName, mimeType) {
+  const ext = normalizeExt(extFromName(downloadName));
+  if (String(mimeType).startsWith("image/")) return "image";
+  if (mimeType === "application/pdf" || ext === "pdf") return "pdf";
+  if (String(mimeType).startsWith("audio/")) return "audio";
+  if (String(mimeType).startsWith("video/")) return "video";
+  if (["txt", "md", "json", "csv", "tsv", "xml", "yaml", "yml", "log", "html"].includes(ext)) return "text";
+  return "unsupported";
+}
+
+function registerDownload(filePath, downloadName, mimeType) {
   const id = randomUUID();
   downloads.set(id, {
     filePath,
@@ -231,7 +241,15 @@ function downloadUrlFor(filePath, downloadName, mimeType) {
     mimeType,
     createdAt: Date.now()
   });
-  return `/downloads/${id}`;
+  return {
+    downloadUrl: `/downloads/${id}`,
+    previewUrl: `/previews/${id}`,
+    previewKind: previewKindFor(downloadName, mimeType)
+  };
+}
+
+function downloadUrlFor(filePath, downloadName, mimeType) {
+  return registerDownload(filePath, downloadName, mimeType).downloadUrl;
 }
 
 function escapeHtml(value) {
@@ -257,6 +275,8 @@ module.exports = {
   outputExtFor,
   outputNameFor,
   outputPathFor,
+  previewKindFor,
+  registerDownload,
   downloadUrlFor,
   escapeHtml
 };

--- a/win7-build-profile.js
+++ b/win7-build-profile.js
@@ -10,6 +10,8 @@ const STAGING_EXCLUDED_TESTS = new Set([
 
 const REQUIRED_RUNTIME_FILES = [
   "electron-main.js",
+  "cli.js",
+  "agent-skill-installer.js",
   "electron-security.js",
   "preload.js",
   "server.js",


### PR DESCRIPTION
## 改动说明

这次补充了三个相互配套的能力，尽量复用现有转换链路，并保持原有鼠鼠 UI、Electron 沙箱和本地回环服务边界不变。

### 1. 转换结果预览

- 单文件结果和批量队列结果都增加“预览”按钮。
- 桌面宽度从右侧滑出抽屉；窄窗口自动切换为底部面板。
- 支持图片、PDF、纯文本/Markdown/JSON/CSV/XML/YAML/HTML 源文本、音频和视频。
- ZIP、Office 等不适合安全内嵌的格式显示文件信息和明确提示。
- 支持 Esc 关闭、焦点恢复、可见焦点样式和 `prefers-reduced-motion`。
- 新增 `/previews/:id` 只读路由，与下载登记表共用随机 ID，不向渲染器暴露真实文件路径；使用 inline disposition、`nosniff` 和限制性 CSP。

### 2. 完整 CLI

CLI 通过随机 `127.0.0.1` 本地服务调用现有 API，因此 GUI 与命令行共用同一套格式判断、转换实现、错误码、资源限制和商店版加密音频限制。

支持：

- `capabilities`
- `targets <file|extension>`
- `convert <files...> --to <format>`
- `images-to-pdf <images...>`
- `merge-pdfs <pdfs...>`
- `--output` / `--output-dir`
- `--compression-level`
- `--video-codec`
- `--pdf-action` / `--password`
- `--json`

源码可使用 `node cli.js ...`；打包后可使用：

- macOS：`FlyingMouse Format.app/Contents/MacOS/FlyingMouse Format --cli ...`
- Windows：`FlyingMouse Format.exe --cli ...`

JSON 模式会把运行诊断写到 stderr，stdout 保持为单一、稳定、可解析的 JSON；PDF 密码不会出现在 JSON 错误中。

### 3. Agent skill 与应用内接入

- 内置轻量 `flyingmouse-format` skill，只负责定位并调用应用 CLI，不复制转换引擎或业务逻辑。
- 顶部“导出诊断”左侧增加“接入 Agent / Connect to Agent”。
- 自动发现已经存在的：
  - `$CODEX_HOME/skills` 或 `~/.codex/skills`
  - `~/.claude/skills`
  - `~/.agents/skills`
  - Windows 用户目录下的对应路径
- 不会静默创建用户尚未使用的 Agent 产品目录。
- 安装前展示目标并二次确认；安装使用临时目录和原子替换，并拒绝目标目录或 skill 源中的符号链接。
- skill 已包含 `SKILL.md`、`agents/openai.yaml` 和跨平台 Node 启动器。

### 4. 打包与兼容

- 新模块已加入 Electron `build.files`。
- Agent skill 资源已加入安装包。
- Win7 staging 清单已同步 CLI 和安装器模块。
- 保持 `contextIsolation: true`、`nodeIntegration: false`、`sandbox: true`。
- 新增 IPC 均调用 `assertTrustedIpc(event)`。
- 未放宽下载 URL 的同源白名单，也未让 CLI 绕过 Microsoft Store 的加密音频限制。

## 验证结果

- `npm run test:ci`：294 通过，0 失败，7 跳过。
- 新增 CLI / 预览 / Agent 安装器 / Electron 安全定向测试：全部通过。
- `npm audit --omit=dev`：0 个生产依赖漏洞。
- Agent skill 使用官方 `quick_validate.py`：通过。
- Win7：使用 Node 22 执行 `node scripts/build-win7.js --prepare-only`，staging 成功且包含新增模块和 skill。
- macOS arm64：完成无引擎资源的 `.app` 目录构建；打包后的 `--cli targets` 和实际文本转换成功。
- UI 实测：真实 README.md → TXT 转换后，主结果与队列均出现预览按钮，文本抽屉内容正常；375 / 768 / 1024 / 1440 宽度响应式符合预期，Esc 可关闭，控制台无错误。
- 带本机 FFmpeg / LibreOffice / Poppler 路径运行完整转换测试：除本机 Homebrew FFmpeg 未编译 WebP 编码器导致既有 animated WebP fixture 无法生成外，其余 44 项通过、2 项真实样本测试跳过；该失败发生在测试输入生成阶段，与本次改动无关。

## 说明

本 PR 不包含 `dist/`、`output/`、下载的引擎资源或本地规划文件。
