### PR TITLE
feat: 支持标准 CAJ 转 PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 - 鼠鼠原版界面：鼠鼠会跟随上传、识别、批量、OCR、转换成功或失败切换状态。
 - 本地离线转换：内置 FFmpeg、LibreOffice、Poppler、Tesseract 和 AVS3 解码器。
-- 支持图片、文本、Word/WPS、Excel/WPS、PPT/WPS、PDF、音频、视频和 ZIP。
+- 支持图片、文本、Word/WPS、Excel/WPS、PPT/WPS、PDF、CAJ、音频、视频和 ZIP。
 - 音频转换：支持 MP3 / WAV / FLAC / M4A / AAC / OGG / OPUS / WMA 等普通格式互转；**不支持其他音乐平台的加密特殊格式**（如 NCM / KGG / mflac / kgma / kwm 等）。
 - 视频编码选择：转视频时可选 H.264 / H.265 / AV1 编码（目标 mp4/mov/mkv 时显示）。
 - 操作记忆：按“源文件格式”分别记住上次选择的目标格式；重新修改后，新选择会成为该源格式的默认值。
@@ -190,6 +190,7 @@ Use `node scripts/build-win7.js --prepare-only` only to inspect staging without 
 | Excel/WPS | xls, xlsx, xlsm, ods, csv, tsv, et, ett | pdf, xlsx, xls, ods, csv, html |
 | PPT/WPS | ppt, pptx, odp, dps, dpt | pdf, pptx, odp, html, png, jpg (逐页转图 zip) |
 | PDF | pdf | xlsx, docx, txt, html, png, jpg, split/解密 PDF |
+| CAJ（知网） | caj | pdf（标准 CAJ；HN/C8/KDH/TEB 暂不支持） |
 | Audio / 音频 | mp3, wav, flac, m4a, aac, ogg, opus, wma | mp3, wav, flac, m4a, ogg, aac, opus, wma |
 | Video / 视频 | mp4, mov, mkv, webm, avi, m4v, wmv, flv | mp4, webm, mkv, mov, gif, mp3, wav, flac, m4a, ogg, aac, opus, wma |
 | ZIP / 压缩包 | zip | pdf (图片合并) |

--- a/caj-convert.js
+++ b/caj-convert.js
@@ -1,0 +1,169 @@
+// CAJ -> PDF conversion for the classic CAJ container.
+// Some .caj downloads are already PDFs; classic CAJ stores disordered PDF objects.
+
+const fsp = require("fs/promises");
+const { PDFDocument } = require("pdf-lib");
+
+const MAX_CAJ_BYTES = 1024 * 1024 * 1024;
+
+class CajConversionError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "CajConversionError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function detectCajVariant(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 4) return "unknown";
+  if (buffer.subarray(0, 4).toString("latin1") === "%PDF") return "pdf";
+  if (buffer[0] === 0xc8) return "c8";
+  const signature = buffer.subarray(0, 4).toString("latin1").replace(/\0/g, "").trim().toUpperCase();
+  if (signature === "CAJ") return "caj";
+  if (signature.startsWith("HN")) return "hn";
+  if (signature === "KDH") return "kdh";
+  if (signature === "TEB") return "teb";
+  return "unknown";
+}
+
+function invalidCaj(reason) {
+  return new CajConversionError("CAJ_INVALID", "CAJ 文件结构损坏或无法识别。", { reason });
+}
+
+function extractClassicCajPdfObjects(buffer) {
+  if (buffer.length < 0x1c) throw invalidCaj("header-too-short");
+  const pageCount = buffer.readInt32LE(0x10);
+  const pointerOffset = buffer.readInt32LE(0x14);
+  if (pageCount < 1 || pageCount > 100000) throw invalidCaj("invalid-page-count");
+  if (pointerOffset < 0 || pointerOffset + 4 > buffer.length) throw invalidCaj("invalid-pdf-pointer-offset");
+  const pdfStart = buffer.readInt32LE(pointerOffset);
+  if (pdfStart < 0 || pdfStart >= buffer.length) throw invalidCaj("invalid-pdf-start");
+  const source = buffer.subarray(pdfStart).toString("latin1");
+  const starts = [...source.matchAll(/(?:^|[\r\n])(\d+)\s+(\d+)\s+obj\b/g)];
+  const objects = new Map();
+  for (const match of starts) {
+    const start = match.index + (match[0].startsWith("\r") || match[0].startsWith("\n") ? 1 : 0);
+    const endMarker = source.indexOf("endobj", start);
+    if (endMarker < 0) continue;
+    const number = Number(match[1]);
+    const generation = Number(match[2]);
+    if (!Number.isSafeInteger(number) || number < 1 || generation < 0 || objects.has(number)) continue;
+    objects.set(number, { number, generation, data: source.slice(start, endMarker + 6).trim() });
+  }
+  if (!objects.size) throw invalidCaj("no-pdf-objects");
+  return { pageCount, objects };
+}
+
+function objectBody(object) {
+  return object.data.slice(object.data.indexOf("obj") + 3, object.data.lastIndexOf("endobj"));
+}
+
+function referenceAfter(body, key) {
+  const match = body.match(new RegExp(`${key}\\s+(\\d+)\\s+\\d+\\s+R\\b`));
+  return match ? Number(match[1]) : null;
+}
+
+function countPages(rootNumber, objects, seen = new Set()) {
+  if (seen.has(rootNumber)) return 0;
+  seen.add(rootNumber);
+  const object = objects.get(rootNumber);
+  if (!object) return 0;
+  const body = objectBody(object);
+  if (/\/Type\s*\/Page\b/.test(body)) return 1;
+  const declared = body.match(/\/Count\s+(\d+)/);
+  if (declared) return Number(declared[1]);
+  const kids = body.match(/\/Kids\s*\[([^\]]*)\]/s)?.[1] || "";
+  return [...kids.matchAll(/(\d+)\s+\d+\s+R/g)].reduce((sum, match) => sum + countPages(Number(match[1]), objects, seen), 0);
+}
+
+function addMissingPageTree(objects, expectedPageCount) {
+  let maxNumber = Math.max(...objects.keys());
+  const pageLike = [...objects.values()].filter((object) => /\/Type\s*\/Pages?\b/.test(objectBody(object)));
+  if (!pageLike.length) throw invalidCaj("no-page-objects");
+
+  const missingParents = new Set();
+  for (const object of pageLike) {
+    const parent = referenceAfter(objectBody(object), "\\/Parent");
+    if (parent && !objects.has(parent)) missingParents.add(parent);
+  }
+  for (const parent of missingParents) {
+    const children = pageLike.filter((object) => referenceAfter(objectBody(object), "\\/Parent") === parent);
+    const count = children.reduce((sum, child) => sum + countPages(child.number, objects), 0) || expectedPageCount;
+    objects.set(parent, { number: parent, generation: 0, data: `${parent} 0 obj\n<< /Type /Pages /Kids [${children.map((item) => `${item.number} 0 R`).join(" ")}] /Count ${count} >>\nendobj` });
+    maxNumber = Math.max(maxNumber, parent);
+  }
+
+  const catalog = [...objects.values()].find((object) => /\/Type\s*\/Catalog\b/.test(objectBody(object)));
+  if (catalog) return catalog.number;
+  const roots = [...objects.values()].filter((object) => {
+    const body = objectBody(object);
+    return /\/Type\s*\/Pages\b/.test(body) && !referenceAfter(body, "\\/Parent");
+  });
+  if (!roots.length) throw invalidCaj("no-page-tree-root");
+  let pagesRoot = roots[0].number;
+  if (roots.length > 1) {
+    pagesRoot = ++maxNumber;
+    const count = roots.reduce((sum, root) => sum + countPages(root.number, objects), 0) || expectedPageCount;
+    objects.set(pagesRoot, { number: pagesRoot, generation: 0, data: `${pagesRoot} 0 obj\n<< /Type /Pages /Kids [${roots.map((item) => `${item.number} 0 R`).join(" ")}] /Count ${count} >>\nendobj` });
+  }
+  const catalogNumber = ++maxNumber;
+  objects.set(catalogNumber, { number: catalogNumber, generation: 0, data: `${catalogNumber} 0 obj\n<< /Type /Catalog /Pages ${pagesRoot} 0 R >>\nendobj` });
+  return catalogNumber;
+}
+
+function rebuildPdf(objects, rootNumber) {
+  const sorted = [...objects.values()].sort((a, b) => a.number - b.number);
+  const maxNumber = sorted.at(-1).number;
+  const chunks = [Buffer.from("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n", "latin1")];
+  const offsets = new Map();
+  let length = chunks[0].length;
+  for (const object of sorted) {
+    offsets.set(object.number, length);
+    const chunk = Buffer.from(`${object.data}\n`, "latin1");
+    chunks.push(chunk);
+    length += chunk.length;
+  }
+  const xrefOffset = length;
+  const xref = ["xref", `0 ${maxNumber + 1}`, "0000000000 65535 f "];
+  for (let number = 1; number <= maxNumber; number += 1) {
+    const object = objects.get(number);
+    xref.push(object ? `${String(offsets.get(number)).padStart(10, "0")} ${String(object.generation).padStart(5, "0")} n ` : "0000000000 65535 f ");
+  }
+  xref.push("trailer", `<< /Size ${maxNumber + 1} /Root ${rootNumber} 0 R >>`, "startxref", String(xrefOffset), "%%EOF", "");
+  chunks.push(Buffer.from(xref.join("\n"), "latin1"));
+  return Buffer.concat(chunks);
+}
+
+async function validatePdf(buffer) {
+  try {
+    const document = await PDFDocument.load(buffer, { ignoreEncryption: true, updateMetadata: false });
+    if (document.getPageCount() < 1) throw new Error("empty PDF");
+  } catch (error) {
+    throw new CajConversionError("CAJ_PDF_REBUILD_FAILED", "已提取 CAJ 内容，但无法重建为有效 PDF。", { reason: error.message });
+  }
+}
+
+async function convertCajToPdf(inputPath, outputPath) {
+  const stat = await fsp.stat(inputPath);
+  if (stat.size > MAX_CAJ_BYTES) throw new CajConversionError("CAJ_TOO_LARGE", "CAJ 文件超过 1 GB，无法安全转换。");
+  const input = await fsp.readFile(inputPath);
+  const variant = detectCajVariant(input);
+  let output;
+  if (variant === "pdf") {
+    output = input;
+  } else if (variant === "caj") {
+    const extracted = extractClassicCajPdfObjects(input);
+    const rootNumber = addMissingPageTree(extracted.objects, extracted.pageCount);
+    output = rebuildPdf(extracted.objects, rootNumber);
+  } else if (["hn", "c8", "kdh", "teb"].includes(variant)) {
+    throw new CajConversionError("CAJ_VARIANT_UNSUPPORTED", `该文件实际为 ${variant.toUpperCase()} 变体，当前版本暂不支持转换。`, { variant });
+  } else {
+    throw new CajConversionError("CAJ_UNKNOWN_FORMAT", "文件扩展名是 CAJ，但内容不是可识别的知网 CAJ 文件。");
+  }
+  await validatePdf(output);
+  await fsp.writeFile(outputPath, output);
+  return { warnings: variant === "pdf" ? [{ code: "CAJ_ALREADY_PDF" }] : [], variant };
+}
+
+module.exports = { CajConversionError, detectCajVariant, extractClassicCajPdfObjects, addMissingPageTree, rebuildPdf, convertCajToPdf };

--- a/config.js
+++ b/config.js
@@ -152,6 +152,8 @@ const ofdOnlyPdfTargets = ["pdf"];
 const documentTargets = ["pdf", "docx", "odt", "rtf", "txt", "html", "md"];
 const spreadsheetInput = new Set(["xls", "xlsx", "xlsm", "ods", "csv", "tsv", "et", "ett"]);
 const spreadsheetTargets = ["pdf", "xlsx", "xls", "ods", "csv", "html"];
+const cajInput = new Set(["caj"]);
+const cajTargets = ["pdf"];
 const presentationInput = new Set(["ppt", "pptx", "odp", "dps", "dpt"]);
 const presentationTargets = ["pdf", "pptx", "odp", "html", "png", "jpg"];
 const pdfInput = new Set(["pdf"]);
@@ -180,6 +182,7 @@ const allTargets = new Set([
   ...textTargets,
   ...documentTargets,
   ...spreadsheetTargets,
+  ...cajTargets,
   ...presentationTargets,
   ...pdfTargets,
   ...mediaTargets,
@@ -218,6 +221,8 @@ module.exports = {
   ofdOnlyPdfTargets,
   spreadsheetInput,
   spreadsheetTargets,
+  cajInput,
+  cajTargets,
   presentationInput,
   presentationTargets,
   pdfInput,

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "flyingmouse-format": "cli.js"
   },
   "scripts": {
-    "pretest": "node --test tests/pdf-structure-engine.test.js tests/pdf-office-docx.test.js tests/pdf-office-xlsx.test.js tests/pdf-structure-score.test.js",
-    "pretest:ci": "node --test tests/pdf-structure-engine.test.js tests/pdf-office-docx.test.js tests/pdf-office-xlsx.test.js tests/pdf-structure-score.test.js",
+    "test:caj": "node --test tests/caj-convert.test.js",
+    "pretest": "node --test tests/caj-convert.test.js tests/pdf-structure-engine.test.js tests/pdf-office-docx.test.js tests/pdf-office-xlsx.test.js tests/pdf-structure-score.test.js",
+    "pretest:ci": "node --test tests/caj-convert.test.js tests/pdf-structure-engine.test.js tests/pdf-office-docx.test.js tests/pdf-office-xlsx.test.js tests/pdf-structure-score.test.js",
     "start": "node server.js",
     "desktop": "electron .",
     "dist": "electron-builder --win nsis --publish never",
@@ -109,6 +110,7 @@
       "pdf.js",
       "text-docx.js",
       "office-convert.js",
+      "caj-convert.js",
       "ofd-convert.js",
       "public/**/*",
       "agent-skill/**/*",

--- a/public/app.js
+++ b/public/app.js
@@ -242,6 +242,7 @@ const labels = {
   text: "文本",
   document: "Word/WPS 文档",
   spreadsheet: "Excel/WPS 表格",
+  caj: "知网 CAJ 文献",
   presentation: "PPT/WPS 演示",
   pdf: "PDF",
   audio: "音频",
@@ -258,7 +259,7 @@ const statusLabels = {
 };
 
 const englishLabels = {
-  image: "Image", text: "Text", document: "Word/WPS document", spreadsheet: "Excel/WPS spreadsheet",
+  image: "Image", text: "Text", document: "Word/WPS document", spreadsheet: "Excel/WPS spreadsheet", caj: "CNKI CAJ document",
   presentation: "PPT/WPS presentation", pdf: "PDF", audio: "Audio", video: "Video", any: "Any file", unknown: "Unknown type"
 };
 const englishStatusLabels = { pending: "Waiting", converting: "Converting", success: "Complete", error: "Failed" };

--- a/server.js
+++ b/server.js
@@ -33,6 +33,7 @@ const { buildPdfTableWorkbook, detectTableLinesFromRaw } = require("./pdf-table-
 const { convertOfdToPdf } = require("./ofd-convert");
 const { OfficeEngineError, probeLibreOffice, runLibreOffice } = require("./office-engine");
 const { inspectXlsxForCsv } = require("./office-quality");
+const { CajConversionError, convertCajToPdf } = require("./caj-convert");
 const logger = require("./logger");
 
 // Prefer the Electron main process's debug.log (set via FLYINGMOUSE_LOG_FILE
@@ -162,6 +163,8 @@ const {
   documentTargets,
   spreadsheetInput,
   spreadsheetTargets,
+  cajInput,
+  cajTargets,
   presentationInput,
   presentationTargets,
   pdfInput,
@@ -350,6 +353,7 @@ app.get("/api/capabilities", async (_req, res) => {
       text: { inputs: [...textInput].sort(), targets: [...textTargets, ...(tools.libreoffice ? ["pdf"] : []), "docx"] },
       document: { inputs: [...documentInput].sort(), targets: documentTargets, experimentalInputs: experimentalInputsByCategory.document },
       spreadsheet: { inputs: [...spreadsheetInput].sort(), targets: spreadsheetTargets, experimentalInputs: experimentalInputsByCategory.spreadsheet },
+      caj: { inputs: [...cajInput], targets: cajTargets, experimentalInputs: [] },
       presentation: { inputs: [...presentationInput].sort(), targets: presentationTargets, experimentalInputs: experimentalInputsByCategory.presentation },
       pdf: { inputs: [...pdfInput].sort(), targets: [...pdfTextTargets, ...(tools.poppler ? [...pdfImageTargets, "pdf"] : [])] },
       audio: { inputs: [...audioInput].sort(), targets: mediaAudioTargets, experimentalInputs: experimentalInputsByCategory.audio },
@@ -573,6 +577,8 @@ app.post("/api/convert", assertLocalWebRequest, upload.single("file"), async (re
       });
     } else if (category === "zip") {
       await convertZipImagesToPdf(file.path, outputPath);
+    } else if (category === "caj") {
+      conversionResult = await convertCajToPdf(file.path, outputPath);
     } else if (category === "spreadsheet" && ["csv", "tsv"].includes(inputExt) && ["txt", "md", "json"].includes(requestedTarget)) {
       conversionResult = await convertText(file.path, outputPath, inputExt, requestedTarget, originalName);
     } else if (category === "spreadsheet" && ["csv", "tsv"].includes(inputExt) && ["epub", "xlsx", "html", "pdf"].includes(requestedTarget)) {
@@ -667,6 +673,7 @@ app.post("/api/convert", assertLocalWebRequest, upload.single("file"), async (re
     ].includes(error?.code);
     const isResourceLimitError = error instanceof ResourceLimitError;
     const isOfficeEngineError = error instanceof OfficeEngineError;
+    const isCajConversionError = error instanceof CajConversionError;
     if (isClientConversionError || isResourceLimitError) logger.warn(`Convert rejected: "${originalName}" -> ${requestedTarget}`, error);
     else logger.error(`Convert failed: "${originalName}" -> ${requestedTarget}`, error);
     await fsp.rm(file.path, { force: true }).catch(() => {});
@@ -678,7 +685,8 @@ app.post("/api/convert", assertLocalWebRequest, upload.single("file"), async (re
       payload.messages = error.messages;
       payload.details = error.details;
     }
-    res.status(isResourceLimitError ? 413 : (isClientConversionError ? 422 : 500)).json(payload);
+    if (isCajConversionError && error.details) payload.details = error.details;
+    res.status(isResourceLimitError || error?.code === "CAJ_TOO_LARGE" ? 413 : (isClientConversionError || isCajConversionError ? 422 : 500)).json(payload);
   }
 });
 

--- a/tests/caj-convert.test.js
+++ b/tests/caj-convert.test.js
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+const { PDFDocument } = require("pdf-lib");
+const { detectCajVariant, extractClassicCajPdfObjects, addMissingPageTree, rebuildPdf, convertCajToPdf } = require("../caj-convert");
+const { categoryForExt, targetsForExt } = require("../utils");
+
+function syntheticClassicCaj() {
+  const objects = "1 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >>\nendobj\n";
+  const pdfStart = 0x80;
+  const pointerOffset = 0x40;
+  const buffer = Buffer.alloc(pdfStart + Buffer.byteLength(objects, "latin1"));
+  buffer.write("CAJ", 0, "ascii");
+  buffer.writeInt32LE(1, 0x10);
+  buffer.writeInt32LE(pointerOffset, 0x14);
+  buffer.writeInt32LE(pdfStart, pointerOffset);
+  buffer.write(objects, pdfStart, "latin1");
+  return buffer;
+}
+
+test("detects CAJ container variants", () => {
+  assert.equal(detectCajVariant(Buffer.from("%PDF-1.7")), "pdf");
+  assert.equal(detectCajVariant(Buffer.from("CAJ\0data", "latin1")), "caj");
+  assert.equal(detectCajVariant(Buffer.from("HN\0\0data", "latin1")), "hn");
+  assert.equal(detectCajVariant(Buffer.from([0xc8, 0, 0, 0])), "c8");
+  assert.equal(detectCajVariant(Buffer.from("nope")), "unknown");
+});
+
+test("rebuilds classic CAJ PDF objects and missing page tree", async () => {
+  const extracted = extractClassicCajPdfObjects(syntheticClassicCaj());
+  const root = addMissingPageTree(extracted.objects, extracted.pageCount);
+  const pdf = rebuildPdf(extracted.objects, root);
+  assert.equal((await PDFDocument.load(pdf)).getPageCount(), 1);
+});
+
+test("converts PDF-backed CAJ and rejects unsupported variants", async () => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "flyingmouse-caj-"));
+  const document = await PDFDocument.create();
+  document.addPage([100, 100]);
+  const input = path.join(root, "paper.caj");
+  const output = path.join(root, "paper.pdf");
+  await fsp.writeFile(input, await document.save());
+  assert.equal((await convertCajToPdf(input, output)).variant, "pdf");
+  assert.equal((await PDFDocument.load(await fsp.readFile(output))).getPageCount(), 1);
+  await fsp.writeFile(input, Buffer.from("HN\0\0unsupported", "latin1"));
+  await assert.rejects(convertCajToPdf(input, output), (error) => error.code === "CAJ_VARIANT_UNSUPPORTED");
+});
+
+test("CAJ is exposed only as a PDF source conversion", () => {
+  assert.equal(categoryForExt("caj"), "caj");
+  assert.deepEqual(new Set(targetsForExt("caj", {})), new Set(["zip", "pdf"]));
+});

--- a/utils.js
+++ b/utils.js
@@ -21,6 +21,8 @@ const {
   ofdOnlyPdfTargets,
   spreadsheetInput,
   spreadsheetTargets,
+  cajInput,
+  cajTargets,
   presentationInput,
   presentationTargets,
   pdfInput,
@@ -118,6 +120,7 @@ function categoryForExt(rawExt) {
   if (pdfInput.has(ext) || pdfInput.has(rawExt)) return "pdf";
   if (documentInput.has(ext) || documentInput.has(rawExt)) return "document";
   if (spreadsheetInput.has(ext) || spreadsheetInput.has(rawExt)) return "spreadsheet";
+  if (cajInput.has(ext) || cajInput.has(rawExt)) return "caj";
   if (presentationInput.has(ext) || presentationInput.has(rawExt)) return "presentation";
   if (textInput.has(ext) || textInput.has(rawExt)) return "text";
   if (audioInput.has(ext) || audioInput.has(rawExt)) return "audio";
@@ -177,6 +180,8 @@ function targetsForExt(rawExt, tools) {
   if (category === "spreadsheet" && tools.libreoffice) {
     spreadsheetTargets.forEach((target) => targets.add(target));
   }
+
+  if (category === "caj") cajTargets.forEach((target) => targets.add(target));
 
   if (["csv", "tsv"].includes(normalizeExt(rawExt))) {
     textTargets.forEach((target) => targets.add(target));

--- a/win7-build-profile.js
+++ b/win7-build-profile.js
@@ -42,7 +42,8 @@ const REQUIRED_RUNTIME_FILES = [
   "pdf-table.js",
   "pdf.js",
   "text-docx.js",
-  "office-convert.js"
+  "office-convert.js",
+  "caj-convert.js"
 ];
 
 function cloneJson(value) {


### PR DESCRIPTION
## 功能说明

实现 Issue #53 请求的知网 CAJ → PDF 离线转换。

- 识别标准 CAJ、PDF-backed CAJ、HN、C8、KDH 和 TEB 文件头
- 标准 CAJ 提取内部 PDF 对象，并重建缺失的页面树、Catalog、xref 与 trailer
- 扩展名为 `.caj`、内容实际为 PDF 时直接校验并输出
- HN/C8/KDH/TEB 当前返回明确的稳定错误，不生成损坏文件
- 接入现有 UI、CLI、批量转换、能力查询和 Win7 打包清单
- 输出前使用 `pdf-lib` 校验页数和 PDF 有效性
- 添加 1 GB 文件安全上限

## 测试

执行相关回归测试：52 项中 51 项通过，1 项因本地缺少 LibreOffice 跳过，0 项失败。

新增测试覆盖：

- CAJ/PDF/HN/C8 等文件头识别
- 标准 CAJ 中缺失页面树和 Catalog 的重建
- PDF-backed CAJ 转换
- 不支持变体的稳定错误码
- CAJ 仅暴露 PDF/ZIP 目标格式

## 已知限制

CAJ 是未公开且存在多种内部变体的格式。目前首版聚焦标准 CAJ；HN/C8/KDH/TEB 尚未实现。合并前建议维护者使用真实 CAJ 样本补充验收，遇到未覆盖结构时可继续迭代。

Closes #53