### PR TITLE
修复 0.7.0 构建依赖安全锁

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3326,9 +3326,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -6193,9 +6193,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/win7-package-lock.json
+++ b/win7-package-lock.json
@@ -2969,9 +2969,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
标准版完整依赖审计发现 fast-uri 和 undici 的构建依赖告警。本次仅更新锁定版本：标准版 fast-uri 3.1.5 → 3.1.7、undici 7.28.0 → 7.29.1；Win7 锁只同步 fast-uri 3.1.7。

逐项比较确认两个锁文件的全部非 dev 包、根依赖映射、应用版本 0.7.0 和 package.json 均不变。Win7 的 Electron/Sharp/PDF.js 固定版本和 overrides 保留；没有运行时代码或 APPX 变更。

验证：

- 标准版 `npm ci` 成功，完整 `npm audit --json` 与生产依赖审计均为 0。
- 构建、Win7 profile、CI 引擎及 macOS 打包回归 44/44 通过；`git diff --check` 通过。
- 独立 Win7 profile 使用 Node 22.22.0，`npm ci --ignore-scripts` 安装锁图成功。原生安装脚本曾因下载其既有 libvips 文件遇到 TLS 断连而失败，因此不宣称 Win7 原生安装验收。
- Win7 保留的旧运行时完整审计仍有 7 个 high 依赖条目；修复这些条目需要另行评估兼容性，不以强制升级破坏本次范围。当前标准版 APPX 不使用 Win7 运行时。
